### PR TITLE
[FE] Tools 버튼 그룹 구현 / Crop store 등록 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,25 +1,13 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 
-import TimeLine from '@/components/organisms/TimeLine';
+import EditPage from '@/pages/Edit';
 import GlobalStyle from '@/theme/globalStyle';
-import Header from '@/components/organisms/Header';
-import Tools from '@/components/organisms/Tools';
-import VideoContainer from '@/components/organisms/VideoContainer';
-import Loading from '@/components/atoms/Loading';
-import { getMessage } from '@/store/selectors';
 
 const App: React.FC = () => {
-  const message = useSelector(getMessage);
-
   return (
     <>
       <GlobalStyle />
-      {message && <Loading message={message} />}
-      <Header />
-      <VideoContainer />
-      <Tools />
-      <TimeLine />
+      <EditPage />
     </>
   );
 };

--- a/client/src/components/molecules/CropLayer/CropLayer.tsx
+++ b/client/src/components/molecules/CropLayer/CropLayer.tsx
@@ -1,13 +1,12 @@
-import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
 import { Range } from 'react-range';
 import styled from 'styled-components';
+
 import color from '@/theme/colors';
 import convertReactStyleToCSS from '@/utils/convert';
+import video from '@/video';
 
-const STEP = 0.1;
 const MIN = 0;
-const MAX = 100;
 
 interface OverlayProps {
   width: number;
@@ -59,7 +58,9 @@ const Thumb = styled.div`
   }
 `;
 
-const CropLayer = ({ positions, setPositions, duration }) => {
+const CropLayer = ({ positions, setPositions }) => {
+  const MAX = video.getDuration();
+  const STEP = (MAX - MIN) / 1024;
   return (
     <CropLayerDiv>
       <Range
@@ -75,8 +76,8 @@ const CropLayer = ({ positions, setPositions, duration }) => {
             onMouseDown={props.onMouseDown}
             onTouchStart={props.onTouchStart}
           >
-            <Overlay width={positions[0]} direction="left" />
-            <Overlay width={MAX - positions[1]} direction="right" />
+            <Overlay width={(positions[0] / MAX) * 100} direction="left" />
+            <Overlay width={(1 - positions[1] / MAX) * 100} direction="right" />
             <div
               ref={props.ref}
               style={{

--- a/client/src/components/molecules/CropLayer/CropLayer.tsx
+++ b/client/src/components/molecules/CropLayer/CropLayer.tsx
@@ -59,7 +59,7 @@ const Thumb = styled.div`
 `;
 
 const CropLayer = ({ positions, setPositions }) => {
-  const MAX = video.getDuration();
+  const MAX = video.get('duration');
   const STEP = (MAX - MIN) / 1024;
   return (
     <CropLayerDiv>

--- a/client/src/components/molecules/CropLayer/CropLayer.tsx
+++ b/client/src/components/molecules/CropLayer/CropLayer.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { Range } from 'react-range';
 import styled from 'styled-components';
 
 import color from '@/theme/colors';
 import convertReactStyleToCSS from '@/utils/convert';
 import video from '@/video';
+import { crop } from '@/store/currentVideo/actions';
+import { getStartEnd, getCropState } from '@/store/selectors';
 
 const MIN = 0;
 
@@ -58,9 +61,25 @@ const Thumb = styled.div`
   }
 `;
 
-const CropLayer = ({ positions, setPositions }) => {
+const CropLayer = () => {
   const MAX = video.get('duration');
   const STEP = (MAX - MIN) / 1024;
+
+  const { start, end } = useSelector(getStartEnd, shallowEqual);
+  const { isCrop, isCropConfirm } = useSelector(getCropState, shallowEqual);
+
+  const [positions, setPositions] = useState([0, 0]);
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (isCrop) setPositions([start, end]);
+  }, [isCrop]);
+
+  useEffect(() => {
+    if (isCropConfirm) dispatch(crop(positions[0], positions[1]));
+  }, [isCropConfirm]);
+
   return (
     <CropLayerDiv>
       <Range

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -35,13 +35,11 @@ const Thumbnail: React.FC = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (isCrop) {
-      setPosition([start, end]);
-    }
+    if (isCrop) setPosition([start, end]);
   }, [isCrop]);
 
   useEffect(() => {
-    dispatch(crop(position[0], position[1]));
+    if (isCropConfirm) dispatch(crop(position[0], position[1]));
   }, [isCropConfirm]);
 
   const thumbnailRef = useRef<HTMLDivElement>(null);

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -7,12 +7,7 @@ import { cropEnd } from '@/store/actionTypes';
 import Slider from '@/components/atoms/Slider';
 import HoverSlider from '@/components/atoms/HoverSlider';
 import video from '@/video';
-import {
-  getThumbnails,
-  getIsCrop,
-  getIsCropConfirm,
-  getStartEnd,
-} from '@/store/selectors';
+import { getThumbnailsEffect, getStartEnd } from '@/store/selectors';
 import CropLayer from '@/components/molecules/CropLayer';
 
 const StyledDiv = styled.div`
@@ -29,14 +24,14 @@ const StyledImg = styled.img`
 `;
 
 const Thumbnail: React.FC = () => {
-  const thumbnails = useSelector(getThumbnails);
-  const isCrop = useSelector(getIsCrop);
-  const isCropConfirm = useSelector(getIsCropConfirm);
-  // const { thumbnails,isCrop, isCropConfirm } = useSelector(getThumbnailsEffect, shallowEqual);
+  const { thumbnails, isCrop, isCropConfirm } = useSelector(
+    getThumbnailsEffect,
+    shallowEqual
+  );
+  const { start, end } = useSelector(getStartEnd);
 
   const [time, setTime] = useState(0);
   const [position, setPosition] = useState([0, 0]);
-  const { start, end } = useSelector(getStartEnd);
 
   const dispatch = useDispatch();
 

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import { moveTo, crop } from '@/store/currentVideo/actions';
-import { cropEnd } from '@/store/actionTypes';
 import Slider from '@/components/atoms/Slider';
 import HoverSlider from '@/components/atoms/HoverSlider';
 import video from '@/video';
@@ -43,7 +42,6 @@ const Thumbnail: React.FC = () => {
 
   useEffect(() => {
     dispatch(crop(position[0], position[1]));
-    dispatch(cropEnd());
   }, [isCropConfirm]);
 
   const thumbnailRef = useRef<HTMLDivElement>(null);

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -1,12 +1,18 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
-import { moveTo } from '@/store/currentVideo/actions';
+import { moveTo, crop } from '@/store/currentVideo/actions';
+import { cropEnd } from '@/store/actionTypes';
 import Slider from '@/components/atoms/Slider';
 import HoverSlider from '@/components/atoms/HoverSlider';
 import video from '@/video';
-import { getThumbnails } from '@/store/selectors';
+import {
+  getThumbnails,
+  getIsCrop,
+  getIsCropConfirm,
+  getStartEnd,
+} from '@/store/selectors';
 import CropLayer from '@/components/molecules/CropLayer';
 
 const StyledDiv = styled.div`
@@ -24,10 +30,26 @@ const StyledImg = styled.img`
 
 const Thumbnail: React.FC = () => {
   const thumbnails = useSelector(getThumbnails);
+  const isCrop = useSelector(getIsCrop);
+  const isCropConfirm = useSelector(getIsCropConfirm);
+  // const { thumbnails,isCrop, isCropConfirm } = useSelector(getThumbnailsEffect, shallowEqual);
+
   const [time, setTime] = useState(0);
   const [position, setPosition] = useState([0, 0]);
+  const { start, end } = useSelector(getStartEnd);
 
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (isCrop) {
+      setPosition([start, end]);
+    }
+  }, [isCrop]);
+
+  useEffect(() => {
+    dispatch(crop(position[0], position[1]));
+    dispatch(cropEnd());
+  }, [isCropConfirm]);
 
   const thumbnailRef = useRef<HTMLDivElement>(null);
   const hoverSliderRef = useRef<HTMLDivElement>(null);
@@ -71,7 +93,7 @@ const Thumbnail: React.FC = () => {
       onMouseLeave={handleMouseLeave}
       onMouseEnter={handleMouseEnter}
     >
-      <CropLayer positions={position} setPositions={setPosition} />
+      {isCrop && <CropLayer positions={position} setPositions={setPosition} />}
       <HoverSlider hoverSliderRef={hoverSliderRef} hoverTime={time} />
       <Slider thumbnailRef={thumbnailRef} />
       {thumbnails.map(image => {

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { moveTo, crop } from '@/store/currentVideo/actions';
+import { moveTo } from '@/store/currentVideo/actions';
 import Slider from '@/components/atoms/Slider';
 import HoverSlider from '@/components/atoms/HoverSlider';
 import video from '@/video';
-import { getThumbnailsEffect, getStartEnd } from '@/store/selectors';
+import { getThumbnails, getIsCrop } from '@/store/selectors';
 import CropLayer from '@/components/molecules/CropLayer';
 
 const StyledDiv = styled.div`
@@ -23,24 +23,12 @@ const StyledImg = styled.img`
 `;
 
 const Thumbnail: React.FC = () => {
-  const { thumbnails, isCrop, isCropConfirm } = useSelector(
-    getThumbnailsEffect,
-    shallowEqual
-  );
-  const { start, end } = useSelector(getStartEnd);
+  const thumbnails = useSelector(getThumbnails);
+  const isCrop = useSelector(getIsCrop);
 
   const [time, setTime] = useState(0);
-  const [position, setPosition] = useState([0, 0]);
 
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    if (isCrop) setPosition([start, end]);
-  }, [isCrop]);
-
-  useEffect(() => {
-    if (isCropConfirm) dispatch(crop(position[0], position[1]));
-  }, [isCropConfirm]);
 
   const thumbnailRef = useRef<HTMLDivElement>(null);
   const hoverSliderRef = useRef<HTMLDivElement>(null);
@@ -84,7 +72,7 @@ const Thumbnail: React.FC = () => {
       onMouseLeave={handleMouseLeave}
       onMouseEnter={handleMouseEnter}
     >
-      {isCrop && <CropLayer positions={position} setPositions={setPosition} />}
+      {isCrop && <CropLayer />}
       <HoverSlider hoverSliderRef={hoverSliderRef} hoverTime={time} />
       <Slider thumbnailRef={thumbnailRef} />
       {thumbnails.map(image => {

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -75,7 +75,7 @@ const Thumbnail: React.FC = () => {
       {isCrop && <CropLayer />}
       <HoverSlider hoverSliderRef={hoverSliderRef} hoverTime={time} />
       <Slider thumbnailRef={thumbnailRef} />
-      {thumbnails.map(image => {
+      {(isCrop ? video.getThumbnails() : thumbnails).map(image => {
         return <StyledImg key={image} src={image} alt="" />;
       })}
     </StyledDiv>

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -6,8 +6,15 @@ import {
   BsFillSkipEndFill,
   BsFillPlayFill,
   BsFillPauseFill,
+  BsAspectRatio,
+  BsTerminal,
+  BsCheck,
+  BsX,
 } from 'react-icons/bs';
 import { RiScissorsLine } from 'react-icons/ri';
+import { AiOutlineRotateLeft,AiOutlineFullscreenExit,AiOutlineFullscreen} from 'react-icons/ai'
+import { MdRotateLeft, MdRotateRight } from 'react-icons/md';
+import { CgMergeHorizontal, CgMergeVertical} from 'react-icons/cg';
 import webglController from '@/webgl/webglController';
 import ButtonGroup from '@/components/molecules/ButtonGroup';
 import UploadArea from '@/components/molecules/UploadArea';
@@ -32,6 +39,13 @@ interface button {
   message: string;
   type: 'default' | 'transparent';
   children: React.ReactChild;
+}
+
+interface ButtonData {
+  onClicks: (() => void)[];
+  messages: string[];
+  type: string;
+  childrens: any[]
 }
 
 const getVideoToolsData = (
@@ -64,55 +78,60 @@ const getVideoToolsData = (
   },
 ];
 
-const getEditToolsData = (
-  rotateLeft90Degree: () => void,
-  rotateRight90Degree: () => void,
-  reverseUpsideDown: () => void,
-  reverseSideToSide: () => void,
-  enlarge: () => void,
-  reduce: () => void,
-  crop: () => void
+const getEditToolData = (
+  rotateReverse: () => void,
+  ratio: () => void,
+  crop: () => void,
 ): button[] => [
   {
-    onClick: rotateLeft90Degree,
-    message: "Left 90'",
+    onClick: rotateReverse,
+    message: '회전 / 반전',
     type: 'transparent',
-    children: null,
+    children: <AiOutlineRotateLeft size={size.ICON_SIZE} />,
   },
   {
-    onClick: rotateRight90Degree,
-    message: "Right 90'",
+    onClick: ratio,
+    message: '비율',
     type: 'transparent',
-    children: null,
+    children: <BsAspectRatio size={size.ICON_SIZE} />,
   },
-  {
-    onClick: reverseUpsideDown,
-    message: 'Up to Down',
-    type: 'transparent',
-    children: null,
-  },
-  {
-    onClick: reverseSideToSide,
-    message: 'Side to Side',
-    type: 'transparent',
-    children: null,
-  },
-  { onClick: enlarge, message: 'enlarge', type: 'transparent', children: null },
-  { onClick: reduce, message: 'reduce', type: 'transparent', children: null },
   {
     onClick: crop,
-    message: 'crop',
+    message: '자르기',
     type: 'transparent',
     children: <RiScissorsLine size={size.ICON_SIZE} />,
   },
 ];
 
-const EditTool = styled(ButtonGroup)``;
-const VideoTool = styled(ButtonGroup)``;
+const getSubEditToolsData = (buttonData: ButtonData): button[] => {
+  const buttons = [];
+
+  if (!buttonData.onClicks) {
+    return [];
+  }
+
+  for (let i = 0; i < buttonData.onClicks.length; i += 1) {
+    buttons.push({
+      onClick: buttonData.onClicks[i],
+      message: buttonData.messages[i],
+      type: buttonData.type,
+      children: buttonData.childrens[i],
+    })
+  }
+
+  return buttons;
+};
 
 const Tools: React.FC = () => {
   const [play, setPlay] = useState(true); // Fix 스토어로 등록
   const dispatch = useDispatch();
+  const [toolType, setToolType] = useState(null);
+  const [buttonData, setButtonData] = useState({
+    onClicks: null,
+    messages: null,
+    type: null,
+    childrens: null,
+  });
 
   const { start, end } = useSelector(getStartEnd, shallowEqual);
 
@@ -164,10 +183,93 @@ const Tools: React.FC = () => {
   const rotateRight90Degree = () => webglController.rotateRight90Degree();
   const reverseUpsideDown = () => webglController.reverseUpsideDown();
   const reverseSideToSide = () => webglController.reverseSideToSide();
-  const enlarge = () => webglController.enlarge();
-  const reduce = () => webglController.reduce();
+  const rotateReverseMethods = [rotateLeft90Degree, rotateRight90Degree, reverseUpsideDown, reverseSideToSide];
+  const rotateReverseMessages= ['왼쪽', '오른쪽', '상하 반전', '좌우 반전'];
+  const rorateReverseChildrens = [
+    <MdRotateLeft size={size.ICON_SIZE} />,
+    <MdRotateRight size={size.ICON_SIZE} />,
+    <CgMergeHorizontal size={size.ICON_SIZE} />,
+    <CgMergeVertical size={size.ICON_SIZE} />
+  ]
+  
+  const rotateReverse = () => {
+    if (toolType === 'videoEffect') {
+      setToolType(null);
+      setButtonData({
+        onClicks: null,
+        messages: null,
+        type: null,
+        childrens: null,
+      });
+    } else {
+      setToolType('videoEffect');
+      setButtonData({
+        onClicks: rotateReverseMethods,
+        messages: rotateReverseMessages,
+        type: 'transparent',
+        childrens : rorateReverseChildrens,
+      })
+    }
+  }
+  
+  const ratioEnlarge = () => webglController.enlarge();
+  const ratioReduce = () => webglController.reduce();
+  const ratioMethods = [ratioEnlarge, ratioReduce];
+  const ratioMessages= ['확대', '축소'];
+  const ratioChildrens = [
+    <AiOutlineFullscreen size={size.ICON_SIZE} />,
+    <AiOutlineFullscreenExit size={size.ICON_SIZE} />,
+  ]
+
+  const ratio = () => {
+    if (toolType === 'ratio') {
+      setToolType(null);
+      setButtonData({
+        onClicks: null,
+        messages: null,
+        type: null,
+        childrens: null,
+      });
+    } else {
+      setToolType('ratio');
+      setButtonData({
+        onClicks: ratioMethods,
+        messages: ratioMessages,
+        type: 'transparent',
+        childrens : ratioChildrens,
+      })
+    }
+  }
+  
+  const cropInsert = () => webglController.enlarge();
+  const cropConfirm = () => webglController.reduce();
+  const cropCancle = () => webglController.reduce();
+  const cropMethods = [cropInsert, cropConfirm, cropCancle];
+  const cropMessages= ['직접입력', '확인', '취소'];
+  const cropChildrens = [
+    <BsTerminal size={size.ICON_SIZE} />,
+    <BsCheck size={size.ICON_SIZE} />,
+    <BsX size={size.ICON_SIZE} />,
+  ]
+
   const crop = () => {
-    // crop
+    if (toolType === 'crop') {
+      setToolType(null);
+      setButtonData({
+        onClicks: null,
+        messages: null,
+        type: null,
+        childrens: null,
+      });
+    } else {
+      setToolType('crop');
+      setButtonData({
+        onClicks: cropMethods,
+        messages: cropMessages,
+        type: 'transparent',
+        childrens : cropChildrens,
+      })
+    }
   };
 
   return (
@@ -180,17 +282,14 @@ const Tools: React.FC = () => {
           play
         )}
       />
-      <EditTool
-        buttonData={getEditToolsData(
-          rotateLeft90Degree,
-          rotateRight90Degree,
-          reverseUpsideDown,
-          reverseSideToSide,
-          enlarge,
-          reduce,
+      <StyledEditToolDiv>
+        <SubEditTool buttonData={getSubEditToolsData(buttonData)}/>
+        <EditTool buttonData={getEditToolData(
+          rotateReverse,
+          ratio,
           crop
-        )}
-      />
+        )}/>
+      </StyledEditToolDiv>
       <UploadArea />
     </StyledDiv>
   );

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -30,9 +30,24 @@ import { getStartEnd } from '@/store/selectors';
 const StyledDiv = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
   padding: 1rem;
+  height: 10rem;
 `;
+
+const StyledEditToolDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const EditTool = styled(ButtonGroup)`
+  width: 20rem;
+`;
+const SubEditTool = styled(ButtonGroup)`
+  width: 25rem;
+`;
+const VideoTool = styled(ButtonGroup)``;
 
 interface button {
   onClick: () => void;

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -71,7 +71,7 @@ interface props {
 }
 
 const Tools: React.FC<props> = ({ setEdit }) => {
-  const [play, setPlay] = useState(true); // Fix 스토어로 등록
+  const play = useSelector(getPlaying);
   const dispatch = useDispatch();
   const [toolType, setToolType] = useState(null);
   const [buttonData, dispatchButtonData] = useReducer(reducer, initialData);
@@ -93,14 +93,13 @@ const Tools: React.FC<props> = ({ setEdit }) => {
   };
 
   const playPauseVideo = () => {
-    if (play) {
+    if (!play) {
       video.play();
       dispatch(playAction());
     } else {
       video.pause();
       dispatch(pause());
     }
-    setPlay(!play);
   };
 
   document.onkeydown = (event: KeyboardEvent) => {

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -1,20 +1,10 @@
 import React, { useState, useReducer } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import {
-  BsFillSkipStartFill,
-  BsFillSkipEndFill,
-  BsFillPlayFill,
-  BsFillPauseFill,
-  BsAspectRatio,
-} from 'react-icons/bs';
-import { RiScissorsLine } from 'react-icons/ri';
-import { MdScreenRotation } from 'react-icons/md';
 
 import webglController from '@/webgl/webglController';
 import ButtonGroup from '@/components/molecules/ButtonGroup';
 import UploadArea from '@/components/molecules/UploadArea';
-import size from '@/theme/sizes';
 import video from '@/video';
 import {
   play as playAction,
@@ -24,14 +14,33 @@ import {
 import { getStartEnd } from '@/store/selectors';
 import { cropStart, cropCancel, cropConfirm } from '@/store/actionTypes';
 
-import reducer, { initialData, ButtonData, ButtonDataAction } from './reducer';
+import reducer, { initialData, ButtonDataAction } from './reducer';
+import {
+  getEditToolData,
+  getSubEditToolsData,
+  getVideoToolsData,
+} from './buttonData';
+
+const UP = 'up';
+const DOWN = 'down';
 
 const StyledDiv = styled.div`
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
   padding: 1rem;
-  height: 10rem;
+`;
+
+const slide = keyframes`
+  from {
+    transform: translate(0, 50px);
+    opacity: 0;
+  }
+  to {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
 `;
 
 const StyledEditToolDiv = styled.div`
@@ -43,82 +52,25 @@ const StyledEditToolDiv = styled.div`
 const EditTool = styled(ButtonGroup)`
   width: 20rem;
 `;
-const SubEditTool = styled(ButtonGroup)`
+
+const WrapperDiv = styled.div`
   width: 25rem;
+  display: flex;
+  justify-content: center;
+  animation: ${slide} 0.5s -0.1s ease-out;
 `;
+
+const SubEditTool = styled(ButtonGroup)`
+  width: 100%;
+`;
+
 const VideoTool = styled(ButtonGroup)``;
 
-interface button {
-  onClick: () => void;
-  message: string;
-  type: 'default' | 'transparent';
-  children: React.ReactChild;
+interface props {
+  setEdit: Function;
 }
 
-const getVideoToolsData = (
-  backwardVideo: () => void,
-  playPauseVideo: () => void,
-  forwardVideo: () => void,
-  play: boolean
-): button[] => [
-  {
-    onClick: backwardVideo,
-    message: '',
-    type: 'transparent',
-    children: <BsFillSkipStartFill size={size.BIG_ICON_SIZE} />,
-  },
-  {
-    onClick: playPauseVideo,
-    message: '',
-    type: 'transparent',
-    children: play ? (
-      <BsFillPlayFill size={size.BIG_ICON_SIZE} />
-    ) : (
-      <BsFillPauseFill size={size.BIG_ICON_SIZE} />
-    ),
-  },
-  {
-    onClick: forwardVideo,
-    message: '',
-    type: 'transparent',
-    children: <BsFillSkipEndFill size={size.BIG_ICON_SIZE} />,
-  },
-];
-
-const getEditToolData = (
-  rotateReverse: () => void,
-  ratio: () => void,
-  crop: () => void
-): button[] => [
-  {
-    onClick: rotateReverse,
-    message: '회전 / 반전',
-    type: 'transparent',
-    children: <MdScreenRotation size={size.ICON_SIZE} />,
-  },
-  {
-    onClick: ratio,
-    message: '비율',
-    type: 'transparent',
-    children: <BsAspectRatio size={size.ICON_SIZE} />,
-  },
-  {
-    onClick: crop,
-    message: '자르기',
-    type: 'transparent',
-    children: <RiScissorsLine size={size.ICON_SIZE} />,
-  },
-];
-
-const getSubEditToolsData = (buttonData: ButtonData): button[] =>
-  [...Array(buttonData.onClicks?.length)].map((_, idx) => ({
-    onClick: buttonData.onClicks[idx],
-    message: buttonData.messages[idx],
-    type: buttonData.type,
-    children: buttonData.childrens[idx],
-  }));
-
-const Tools: React.FC = () => {
+const Tools: React.FC<props> = ({ setEdit }) => {
   const [play, setPlay] = useState(true); // Fix 스토어로 등록
   const dispatch = useDispatch();
   const [toolType, setToolType] = useState(null);
@@ -148,7 +100,6 @@ const Tools: React.FC = () => {
       video.pause();
       dispatch(pause());
     }
-
     setPlay(!play);
   };
 
@@ -170,6 +121,21 @@ const Tools: React.FC = () => {
     }
   };
 
+  const closeSubtool = () => {
+    setEdit(DOWN);
+    setToolType(null);
+    dispatchButtonData({ type: null });
+  };
+
+  const openSubtool = (
+    type: 'videoEffect' | 'ratio' | 'crop',
+    payload: (() => void)[]
+  ) => {
+    setEdit(UP);
+    setToolType(type);
+    dispatchButtonData({ type, payload });
+  };
+
   const handleRotateLeft90Degree = () => webglController.rotateLeft90Degree();
   const handleRotateRight90Degree = () => webglController.rotateRight90Degree();
   const handleReverseUpsideDown = () => webglController.reverseUpsideDown();
@@ -181,56 +147,37 @@ const Tools: React.FC = () => {
     handleReverseSideToSide,
   ];
 
-  const handleRotateReverse = () => {
-    if (toolType === 'videoEffect') {
-      setToolType(null);
-      dispatchButtonData({ type: null });
-    } else {
-      setToolType('videoEffect');
-      dispatchButtonData({
-        type: 'videoEffect',
-        payload: rotateReverseMethods,
-      });
-    }
-  };
-
   const handleRatioEnlarge = () => webglController.enlarge();
   const handleRatioReduce = () => webglController.reduce();
   const ratioMethods = [handleRatioEnlarge, handleRatioReduce];
 
-  const handleRatio = () => {
-    if (toolType === 'ratio') {
-      setToolType(null);
-      dispatchButtonData({ type: null });
-    } else {
-      setToolType('ratio');
-      dispatchButtonData({ type: 'ratio', payload: ratioMethods });
-    }
-  };
-
-  const handleCropInsert = () => webglController.enlarge();
+  const handleCropInsert = () => null;
   const handleCropConfirm = () => {
     dispatch(cropConfirm());
-    setToolType(null);
-    dispatchButtonData({ type: null });
+    closeSubtool();
     dispatch(cropCancel());
   };
   const handleCropCancel = () => {
-    setToolType(null);
-    dispatchButtonData({ type: null });
+    closeSubtool();
     dispatch(cropCancel());
   };
   const cropMethods = [handleCropInsert, handleCropConfirm, handleCropCancel];
 
+  const handleRotateReverse = () =>
+    toolType === 'videoEffect'
+      ? closeSubtool()
+      : openSubtool('videoEffect', rotateReverseMethods);
+
+  const handleRatio = () =>
+    toolType === 'ratio' ? closeSubtool() : openSubtool('ratio', ratioMethods);
+
   const handleCrop = () => {
     if (toolType === 'crop') {
       dispatch(cropCancel());
-      setToolType(null);
-      dispatchButtonData({ type: null });
+      closeSubtool();
     } else {
+      openSubtool('crop', cropMethods);
       dispatch(cropStart());
-      setToolType('crop');
-      dispatchButtonData({ type: 'crop', payload: cropMethods });
     }
   };
 
@@ -245,7 +192,11 @@ const Tools: React.FC = () => {
         )}
       />
       <StyledEditToolDiv>
-        <SubEditTool buttonData={getSubEditToolsData(buttonData)} />
+        {toolType && (
+          <WrapperDiv>
+            <SubEditTool buttonData={getSubEditToolsData(buttonData)} />
+          </WrapperDiv>
+        )}
         <EditTool
           buttonData={getEditToolData(
             handleRotateReverse,

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -213,7 +213,6 @@ const Tools: React.FC = () => {
     dispatch(cropConfirm());
     setToolType(null);
     dispatchButtonData({ type: null });
-    dispatch(cropCancel());
   };
   const handleCropCancel = () => {
     setToolType(null);

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -131,6 +131,7 @@ const Tools: React.FC<props> = ({ setEdit }) => {
     type: 'videoEffect' | 'ratio' | 'crop',
     payload: (() => void)[]
   ) => {
+    if (type !== 'crop') dispatch(cropCancel());
     setEdit(UP);
     setToolType(type);
     dispatchButtonData({ type, payload });

--- a/client/src/components/organisms/Tools/buttonData.tsx
+++ b/client/src/components/organisms/Tools/buttonData.tsx
@@ -38,9 +38,9 @@ export const getVideoToolsData = (
     message: '',
     type: 'transparent',
     children: play ? (
-      <BsFillPlayFill size={size.BIG_ICON_SIZE} />
-    ) : (
       <BsFillPauseFill size={size.BIG_ICON_SIZE} />
+    ) : (
+      <BsFillPlayFill size={size.BIG_ICON_SIZE} />
     ),
   },
   {

--- a/client/src/components/organisms/Tools/buttonData.tsx
+++ b/client/src/components/organisms/Tools/buttonData.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import {
+  BsFillSkipStartFill,
+  BsFillSkipEndFill,
+  BsFillPlayFill,
+  BsFillPauseFill,
+  BsAspectRatio,
+} from 'react-icons/bs';
+import { RiScissorsLine } from 'react-icons/ri';
+import { MdScreenRotation } from 'react-icons/md';
+
+import size from '@/theme/sizes';
+
+import { ButtonData } from './reducer';
+
+interface button {
+  onClick: () => void;
+  message: string;
+  type: 'default' | 'transparent';
+  children: React.ReactChild;
+}
+
+export const getVideoToolsData = (
+  backwardVideo: () => void,
+  playPauseVideo: () => void,
+  forwardVideo: () => void,
+  play: boolean
+): button[] => [
+  {
+    onClick: backwardVideo,
+    message: '',
+    type: 'transparent',
+    children: <BsFillSkipStartFill size={size.BIG_ICON_SIZE} />,
+  },
+  {
+    onClick: playPauseVideo,
+    message: '',
+    type: 'transparent',
+    children: play ? (
+      <BsFillPlayFill size={size.BIG_ICON_SIZE} />
+    ) : (
+      <BsFillPauseFill size={size.BIG_ICON_SIZE} />
+    ),
+  },
+  {
+    onClick: forwardVideo,
+    message: '',
+    type: 'transparent',
+    children: <BsFillSkipEndFill size={size.BIG_ICON_SIZE} />,
+  },
+];
+
+export const getEditToolData = (
+  rotateReverse: () => void,
+  ratio: () => void,
+  crop: () => void
+): button[] => [
+  {
+    onClick: rotateReverse,
+    message: '회전 / 반전',
+    type: 'transparent',
+    children: <MdScreenRotation size={size.ICON_SIZE} />,
+  },
+  {
+    onClick: ratio,
+    message: '비율',
+    type: 'transparent',
+    children: <BsAspectRatio size={size.ICON_SIZE} />,
+  },
+  {
+    onClick: crop,
+    message: '자르기',
+    type: 'transparent',
+    children: <RiScissorsLine size={size.ICON_SIZE} />,
+  },
+];
+
+export const getSubEditToolsData = (buttonData: ButtonData): button[] =>
+  [...Array(buttonData.onClicks?.length)].map((_, idx) => ({
+    onClick: buttonData.onClicks[idx],
+    message: buttonData.messages[idx],
+    type: buttonData.type,
+    children: buttonData.childrens[idx],
+  }));

--- a/client/src/components/organisms/Tools/reducer.tsx
+++ b/client/src/components/organisms/Tools/reducer.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { BsTerminal, BsCheck, BsX } from 'react-icons/bs';
+import {
+  MdRotateLeft,
+  MdRotateRight,
+  MdZoomIn,
+  MdZoomOut,
+} from 'react-icons/md';
+import { CgMergeHorizontal, CgMergeVertical } from 'react-icons/cg';
+
+import size from '@/theme/sizes';
+
+export interface ButtonData {
+  onClicks: (() => void)[];
+  messages: string[];
+  type: 'default' | 'transparent';
+  childrens: React.ReactChild[];
+}
+
+export interface ButtonDataAction {
+  type: 'crop' | 'videoEffect' | 'ratio' | null;
+  payload?: (() => void)[];
+}
+
+// crop
+const cropMessages = ['직접입력', '확인', '취소'];
+const cropChildrens = [
+  <BsTerminal size={size.ICON_SIZE} />,
+  <BsCheck size={size.ICON_SIZE} />,
+  <BsX size={size.ICON_SIZE} />,
+];
+
+// videoEffect
+const rotateReverseMessages = ['왼쪽', '오른쪽', '상하 반전', '좌우 반전'];
+const rotateReverseChildrens = [
+  <MdRotateLeft size={size.ICON_SIZE} />,
+  <MdRotateRight size={size.ICON_SIZE} />,
+  <CgMergeHorizontal size={size.ICON_SIZE} />,
+  <CgMergeVertical size={size.ICON_SIZE} />,
+];
+
+// ratio
+const ratioMessages = ['확대', '축소'];
+const ratioChildrens = [
+  <MdZoomIn size={size.ICON_SIZE} />,
+  <MdZoomOut size={size.ICON_SIZE} />,
+];
+
+export const initialData: ButtonData = {
+  onClicks: [],
+  messages: [],
+  type: 'transparent',
+  childrens: [],
+};
+
+export default (state: ButtonData, action: ButtonDataAction): ButtonData => {
+  switch (action.type) {
+    case 'crop':
+      return {
+        onClicks: action.payload,
+        messages: cropMessages,
+        type: 'transparent',
+        childrens: cropChildrens,
+      };
+    case 'videoEffect':
+      return {
+        onClicks: action.payload,
+        messages: rotateReverseMessages,
+        type: 'transparent',
+        childrens: rotateReverseChildrens,
+      };
+    case 'ratio':
+      return {
+        onClicks: action.payload,
+        messages: ratioMessages,
+        type: 'transparent',
+        childrens: ratioChildrens,
+      };
+    default:
+      return initialData;
+  }
+};

--- a/client/src/components/organisms/Tools/reducer.tsx
+++ b/client/src/components/organisms/Tools/reducer.tsx
@@ -10,6 +10,12 @@ import { CgMergeHorizontal, CgMergeVertical } from 'react-icons/cg';
 
 import size from '@/theme/sizes';
 
+export enum ButtonTypes {
+  crop = 'crop',
+  videoEffect = 'videoEffect',
+  ratio = 'ratio',
+}
+
 export interface ButtonData {
   onClicks: (() => void)[];
   messages: string[];
@@ -17,8 +23,8 @@ export interface ButtonData {
   childrens: React.ReactChild[];
 }
 
-export interface ButtonDataAction {
-  type: 'crop' | 'videoEffect' | 'ratio' | null;
+interface ButtonDataAction {
+  type: ButtonTypes | null;
   payload?: (() => void)[];
 }
 
@@ -55,21 +61,21 @@ export const initialData: ButtonData = {
 
 export default (state: ButtonData, action: ButtonDataAction): ButtonData => {
   switch (action.type) {
-    case 'crop':
+    case ButtonTypes.crop:
       return {
         onClicks: action.payload,
         messages: cropMessages,
         type: 'transparent',
         childrens: cropChildrens,
       };
-    case 'videoEffect':
+    case ButtonTypes.videoEffect:
       return {
         onClicks: action.payload,
         messages: rotateReverseMessages,
         type: 'transparent',
         childrens: rotateReverseChildrens,
       };
-    case 'ratio':
+    case ButtonTypes.ratio:
       return {
         onClicks: action.payload,
         messages: ratioMessages,

--- a/client/src/components/organisms/VideoContainer/VideoContainer.tsx
+++ b/client/src/components/organisms/VideoContainer/VideoContainer.tsx
@@ -8,7 +8,7 @@ const StyledDiv = styled.div`
 `;
 
 const StyledCanvas = styled.canvas`
-  height: 35rem;
+  height: 30rem;
 `;
 
 const VideoContainer: React.FC = () => {

--- a/client/src/components/organisms/VideoContainer/VideoContainer.tsx
+++ b/client/src/components/organisms/VideoContainer/VideoContainer.tsx
@@ -1,7 +1,36 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 import color from '@/theme/colors';
+
+const UP = 'up';
+const DOWN = 'down';
+
+const slideUp = keyframes`
+  from {
+    transform: translate(0, 2rem);
+  }
+  to {
+    transform: translate(0, 0);
+  }
+`;
+
+const slideDown = keyframes`
+  from {
+    transform: translate(0, -2rem);
+  }
+  to {
+    transform: translate(0, 0);
+  }
+`;
+
+const videoUp = css`
+  animation: ${slideUp} 0.3s ease-out;
+`;
+
+const videoDown = css`
+  animation: ${slideDown} 0.5s ease-out;
+`;
 
 const StyledDiv = styled.div`
   display: flex;
@@ -10,14 +39,20 @@ const StyledDiv = styled.div`
 `;
 
 const StyledCanvas = styled.canvas`
-  height: 30rem;
+  height: 32rem;
   background-color: ${color.BLACK};
+  ${({ isEdit }) => (isEdit === UP ? videoUp : '')};
+  ${({ isEdit }) => (isEdit === DOWN ? videoDown : '')};
 `;
 
-const VideoContainer: React.FC = () => {
+interface props {
+  isEdit: string;
+}
+
+const VideoContainer: React.FC<props> = ({ isEdit }) => {
   return (
     <StyledDiv>
-      <StyledCanvas id="glcanvas" />
+      <StyledCanvas id="glcanvas" isEdit={isEdit} />
     </StyledDiv>
   );
 };

--- a/client/src/pages/edit.tsx
+++ b/client/src/pages/edit.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
+
+import TimeLine from '@/components/organisms/TimeLine';
+import Header from '@/components/organisms/Header';
+import Tools from '@/components/organisms/Tools';
+import VideoContainer from '@/components/organisms/VideoContainer';
+import Loading from '@/components/atoms/Loading';
+import { getMessage } from '@/store/selectors';
+
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100vh;
+  width: 100vw;
+`;
+
+const BottomDiv = styled.div``;
+
+const EditPage: React.FC = () => {
+  const message = useSelector(getMessage);
+  const [isEdit, setEdit] = useState('');
+
+  return (
+    <StyledDiv>
+      {message && <Loading message={message} />}
+      <Header />
+      <VideoContainer isEdit={isEdit} />
+      <BottomDiv>
+        <Tools setEdit={setEdit} />
+        <TimeLine />
+      </BottomDiv>
+    </StyledDiv>
+  );
+};
+
+export default React.memo(EditPage);

--- a/client/src/store/actionTypes.ts
+++ b/client/src/store/actionTypes.ts
@@ -26,8 +26,6 @@ export const cropCancel = () => ({ type: CROP_CANCEL });
 export const CROP_CONFIRM = 'crop/CROP_CONFIRM';
 export const cropConfirm = () => ({ type: CROP_CONFIRM });
 
-export const CROP_END = 'crop/CROP_END';
-export const cropEnd = () => ({ type: CROP_END });
 // history
 
 // global

--- a/client/src/store/actionTypes.ts
+++ b/client/src/store/actionTypes.ts
@@ -16,6 +16,18 @@ export const MOVE_TO = 'current/MOVE_TO';
 export const SET_THUMBNAILS = 'current/SET_THUMBNAILS';
 export const CROP = 'current/CROP';
 
+// crop
+export const CROP_START = 'crop/CROP_START';
+export const cropStart = () => ({ type: CROP_START });
+
+export const CROP_CANCEL = 'crop/CROP_CANCEL';
+export const cropCancel = () => ({ type: CROP_CANCEL });
+
+export const CROP_CONFIRM = 'crop/CROP_CONFIRM';
+export const cropConfirm = () => ({ type: CROP_CONFIRM });
+
+export const CROP_END = 'crop/CROP_END';
+export const cropEnd = () => ({ type: CROP_END });
 // history
 
 // global

--- a/client/src/store/crop/actions.ts
+++ b/client/src/store/crop/actions.ts
@@ -1,0 +1,44 @@
+import {
+  CROP_START,
+  CROP_CANCEL,
+  CROP_CONFIRM,
+  CROP_END,
+} from '../actionTypes';
+
+export const cropStart = () => ({
+  type: typeof CROP_START,
+});
+
+export const cropCancel = () => ({
+  type: typeof CROP_CANCEL,
+});
+
+export const cropConfirm = () => ({
+  type: typeof CROP_CONFIRM,
+});
+
+export const cropEnd = () => ({
+  type: typeof CROP_END,
+});
+
+export type CropStartAction = {
+  type: typeof CROP_START;
+};
+
+export type CropCancelAction = {
+  type: typeof CROP_CANCEL;
+};
+
+export type CropConfirmAction = {
+  type: typeof CROP_CONFIRM;
+};
+
+export type CropEnd = {
+  type: typeof CROP_END;
+};
+
+export type CropAction =
+  | CropStartAction
+  | CropCancelAction
+  | CropConfirmAction
+  | CropEnd;

--- a/client/src/store/crop/actions.ts
+++ b/client/src/store/crop/actions.ts
@@ -1,9 +1,4 @@
-import {
-  CROP_START,
-  CROP_CANCEL,
-  CROP_CONFIRM,
-  CROP_END,
-} from '../actionTypes';
+import { CROP_START, CROP_CANCEL, CROP_CONFIRM, CROP } from '../actionTypes';
 
 export const cropStart = () => ({
   type: typeof CROP_START,
@@ -15,10 +10,6 @@ export const cropCancel = () => ({
 
 export const cropConfirm = () => ({
   type: typeof CROP_CONFIRM,
-});
-
-export const cropEnd = () => ({
-  type: typeof CROP_END,
 });
 
 export type CropStartAction = {
@@ -33,12 +24,12 @@ export type CropConfirmAction = {
   type: typeof CROP_CONFIRM;
 };
 
-export type CropEnd = {
-  type: typeof CROP_END;
+export type Crop = {
+  type: typeof CROP;
 };
 
 export type CropAction =
   | CropStartAction
   | CropCancelAction
   | CropConfirmAction
-  | CropEnd;
+  | Crop;

--- a/client/src/store/crop/reducer.ts
+++ b/client/src/store/crop/reducer.ts
@@ -1,9 +1,4 @@
-import {
-  CROP_START,
-  CROP_CANCEL,
-  CROP_CONFIRM,
-  CROP_END,
-} from '../actionTypes';
+import { CROP_START, CROP_CANCEL, CROP_CONFIRM, CROP } from '../actionTypes';
 import { CropAction } from './actions';
 
 export interface CropState {
@@ -36,7 +31,7 @@ export default (
         ...state,
         isCropConfirm: true,
       };
-    case CROP_END: // -> CROP
+    case CROP:
       return {
         ...state,
         isCropConfirm: false,

--- a/client/src/store/crop/reducer.ts
+++ b/client/src/store/crop/reducer.ts
@@ -1,0 +1,47 @@
+import {
+  CROP_START,
+  CROP_CANCEL,
+  CROP_CONFIRM,
+  CROP_END,
+} from '../actionTypes';
+import { CropAction } from './actions';
+
+export interface CropState {
+  isCrop: boolean;
+  isCropConfirm: boolean;
+}
+
+const initialState: CropState = {
+  isCrop: false,
+  isCropConfirm: false,
+};
+
+export default (
+  state: CropState = initialState,
+  action: CropAction
+): CropState => {
+  switch (action.type) {
+    case CROP_START:
+      return {
+        ...state,
+        isCrop: true,
+      };
+    case CROP_CANCEL:
+      return {
+        ...state,
+        isCrop: false,
+      };
+    case CROP_CONFIRM:
+      return {
+        ...state,
+        isCropConfirm: true,
+      };
+    case CROP_END: // -> CROP
+      return {
+        ...state,
+        isCropConfirm: false,
+      };
+    default:
+      return state;
+  }
+};

--- a/client/src/store/crop/reducer.ts
+++ b/client/src/store/crop/reducer.ts
@@ -29,12 +29,11 @@ export default (
     case CROP_CONFIRM:
       return {
         ...state,
-        isCrop: false,
         isCropConfirm: true,
       };
     case CROP:
       return {
-        ...state,
+        isCrop: false,
         isCropConfirm: false,
       };
     default:

--- a/client/src/store/crop/reducer.ts
+++ b/client/src/store/crop/reducer.ts
@@ -29,6 +29,7 @@ export default (
     case CROP_CONFIRM:
       return {
         ...state,
+        isCrop: false,
         isCropConfirm: true,
       };
     case CROP:

--- a/client/src/store/reducer.ts
+++ b/client/src/store/reducer.ts
@@ -1,15 +1,18 @@
 import { combineReducers } from 'redux';
 import originalVideo, { OriginalVideoState } from './originalVideo/reducer';
 import currentVideo, { CurrentVideoState } from './currentVideo/reducer';
+import crop, { CropState } from './crop/reducer';
 
 export interface RootState {
   originalVideo: OriginalVideoState;
   currentVideo: CurrentVideoState;
+  crop: CropState;
 }
 
 const reducers = {
   originalVideo,
   currentVideo,
+  crop,
 };
 
 export default combineReducers(reducers);

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -31,12 +31,11 @@ export const getIsCrop = (state: RootState) => state.crop.isCrop;
 
 export const getIsCropConfirm = (state: RootState) => state.crop.isCropConfirm;
 
-export const getThumbnailsEffect = (state: RootState) => {
-  const { thumbnails } = state.currentVideo;
-  const { isCrop, isCropConfirm } = state.crop;
+export const getCropState = (state: RootState) => {
+  const { isCrop } = state.crop;
+  const { isCropConfirm } = state.crop;
 
   return {
-    thumbnails,
     isCrop,
     isCropConfirm,
   };

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -25,3 +25,12 @@ export const getStartEnd = (state: RootState) => {
 };
 export const getThumbnails = (state: RootState) =>
   state.currentVideo.thumbnails;
+
+// crop
+export const getIsCrop = (state: RootState) => state.crop.isCrop;
+
+export const getIsCropConfirm = (state: RootState) => state.crop.isCropConfirm;
+
+//  export getThumbnailsEffect = (state:RootState) => {
+//   return {state.currentVideo.thumbnails,state.crop.isCrop,state.crop.isCropConfirm}
+//  }

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -31,6 +31,13 @@ export const getIsCrop = (state: RootState) => state.crop.isCrop;
 
 export const getIsCropConfirm = (state: RootState) => state.crop.isCropConfirm;
 
-//  export getThumbnailsEffect = (state:RootState) => {
-//   return {state.currentVideo.thumbnails,state.crop.isCrop,state.crop.isCropConfirm}
-//  }
+export const getThumbnailsEffect = (state: RootState) => {
+  const { thumbnails } = state.currentVideo;
+  const { isCrop, isCropConfirm } = state.crop;
+
+  return {
+    thumbnails,
+    isCrop,
+    isCropConfirm,
+  };
+};


### PR DESCRIPTION
# 개요
- Tools 버튼그룹 구현
- Crop store 등록

# 체크리스트
- [x] 회전 / 반전, 비율, 자르기 버튼 그룹이 보인다.
- [x] 각각의 메뉴를 선택했을 시, 영상 canvas와 같이 위쪽으로 이동하는 애니메이션을 통해 하위메뉴가 나타난다.
- [x] 자르기 메뉴를 선택했을 시, 하단에 Crop Layer가 나타난다.
- [x] Crop Layer의 thumb를 드래그하거나 썸네일을 클릭하여 thumb를 이동할 수 있다.
- [x] 다시 자르기 메뉴를 선택하거나, 취소 버튼을 선택하면 Crop Layer가 사라진다.