### PR TITLE
[FE] Crop 이후 slider / currentTime 로직 수정 및 오류 수정

### DIFF
--- a/client/src/components/atoms/Slider/Slider.tsx
+++ b/client/src/components/atoms/Slider/Slider.tsx
@@ -2,7 +2,7 @@ import React, { MutableRefObject, useEffect, useState } from 'react';
 import styled, { keyframes, css } from 'styled-components';
 import { useSelector } from 'react-redux';
 
-import { getPlaying, getCurrentTime } from '@/store/selectors';
+import { getPlaying, getCurrentTime, getStartEnd } from '@/store/selectors';
 import color from '@/theme/colors';
 import video from '@/video';
 
@@ -35,6 +35,7 @@ const StyledDiv = styled.div`
 const Slider: React.FC<Props> = ({ thumbnailRef }) => {
   const [location, setLocation] = useState(0);
   const [duration, setDuration] = useState(0);
+  const { start, end } = useSelector(getStartEnd);
 
   const isPlaying = useSelector(getPlaying);
   const time = useSelector(getCurrentTime);
@@ -43,10 +44,10 @@ const Slider: React.FC<Props> = ({ thumbnailRef }) => {
     const currentTime = video.get('currentTime');
 
     const width = thumbnailRef.current.clientWidth;
-    const totalDuration = video.get('duration');
+    const totalDuration = end - start;
 
     const movedLocation = totalDuration
-      ? (currentTime / totalDuration) * width
+      ? ((currentTime - start) / totalDuration) * width
       : 0;
 
     const restWidth = width - movedLocation;

--- a/client/src/components/atoms/Slider/Slider.tsx
+++ b/client/src/components/atoms/Slider/Slider.tsx
@@ -1,6 +1,6 @@
 import React, { MutableRefObject, useEffect, useState } from 'react';
 import styled, { keyframes, css } from 'styled-components';
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 
 import { getPlaying, getCurrentTime, getStartEnd } from '@/store/selectors';
 import color from '@/theme/colors';
@@ -35,7 +35,7 @@ const StyledDiv = styled.div`
 const Slider: React.FC<Props> = ({ thumbnailRef }) => {
   const [location, setLocation] = useState(0);
   const [duration, setDuration] = useState(0);
-  const { start, end } = useSelector(getStartEnd);
+  const { start, end } = useSelector(getStartEnd, shallowEqual);
 
   const isPlaying = useSelector(getPlaying);
   const time = useSelector(getCurrentTime);

--- a/client/src/components/molecules/CurrentTime/CurrentTime.tsx
+++ b/client/src/components/molecules/CurrentTime/CurrentTime.tsx
@@ -38,7 +38,7 @@ const CurrentTime: React.FC = () => {
         if (newTime >= end) {
           if (!cropState.isCrop) video.pause();
           dispatch(pause());
-          newTime = end;
+          if (newTime > end) video.setCurrentTime((newTime = end));
           dispatch(moveTo(end));
         }
         newTime = Math.floor(newTime - start);

--- a/client/src/components/molecules/CurrentTime/CurrentTime.tsx
+++ b/client/src/components/molecules/CurrentTime/CurrentTime.tsx
@@ -24,7 +24,7 @@ const StyledDiv = styled.div`
 const CurrentTime: React.FC = () => {
   const currentTime = () => video.get('currentTime');
   const { start, end } = useSelector(getStartEnd, shallowEqual);
-  const cropState = useSelector(getIsCropAndDuration);
+  const cropState = useSelector(getIsCropAndDuration, shallowEqual);
   const [time, setTime] = useState(Math.floor(currentTime() - start));
   const visible = useSelector(getVisible);
 

--- a/client/src/components/molecules/CurrentTime/CurrentTime.tsx
+++ b/client/src/components/molecules/CurrentTime/CurrentTime.tsx
@@ -1,11 +1,16 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import styled from 'styled-components';
 
 import TimeText from '@/components/atoms/TimeText';
 import video from '@/video';
 import color from '@/theme/colors';
-import { getVisible } from '@/store/selectors';
+import {
+  getVisible,
+  getIsCropAndDuration,
+  getStartEnd,
+} from '@/store/selectors';
+import { moveTo, pause } from '@/store/currentVideo/actions';
 
 const StyledDiv = styled.div`
   display: flex;
@@ -17,16 +22,26 @@ const StyledDiv = styled.div`
 `;
 
 const CurrentTime: React.FC = () => {
-  const currentTime = () => Math.round(video.get('currentTime'));
-
-  const [time, setTime] = useState(currentTime());
+  const currentTime = () => video.get('currentTime');
+  const { start, end } = useSelector(getStartEnd, shallowEqual);
+  const cropState = useSelector(getIsCropAndDuration);
+  const [time, setTime] = useState(Math.floor(currentTime() - start));
   const visible = useSelector(getVisible);
+
+  const dispatch = useDispatch();
 
   useEffect(() => {
     const timer =
       visible &&
       setInterval(() => {
-        const newTime = currentTime();
+        let newTime = currentTime();
+        if (newTime >= end) {
+          if (!cropState.isCrop) video.pause();
+          dispatch(pause());
+          newTime = end;
+          dispatch(moveTo(end));
+        }
+        newTime = Math.floor(newTime - start);
         if (time !== newTime) setTime(newTime);
       }, 50);
     return () => clearInterval(timer);

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
-import { useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
 import { moveTo } from '@/store/currentVideo/actions';
 import Slider from '@/components/atoms/Slider';
@@ -25,7 +25,7 @@ const StyledImg = styled.img`
 const Thumbnail: React.FC = () => {
   const thumbnails = useSelector(getThumbnails);
   const isCrop = useSelector(getIsCrop);
-  const { start, end } = useSelector(getStartEnd);
+  const { start, end } = useSelector(getStartEnd, shallowEqual);
 
   const [time, setTime] = useState(0);
 

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -6,7 +6,7 @@ import { moveTo } from '@/store/currentVideo/actions';
 import Slider from '@/components/atoms/Slider';
 import HoverSlider from '@/components/atoms/HoverSlider';
 import video from '@/video';
-import { getThumbnails, getIsCrop } from '@/store/selectors';
+import { getThumbnails, getIsCrop, getStartEnd } from '@/store/selectors';
 import CropLayer from '@/components/molecules/CropLayer';
 
 const StyledDiv = styled.div`
@@ -25,6 +25,7 @@ const StyledImg = styled.img`
 const Thumbnail: React.FC = () => {
   const thumbnails = useSelector(getThumbnails);
   const isCrop = useSelector(getIsCrop);
+  const { start, end } = useSelector(getStartEnd);
 
   const [time, setTime] = useState(0);
 
@@ -34,9 +35,9 @@ const Thumbnail: React.FC = () => {
   const hoverSliderRef = useRef<HTMLDivElement>(null);
 
   const handleClick = () => {
-    video.setCurrentTime(time);
+    video.setCurrentTime(start + time);
 
-    dispatch(moveTo(time));
+    dispatch(moveTo(start + time));
   };
 
   const handleMouseMove = (event: MouseEvent) => {
@@ -48,7 +49,7 @@ const Thumbnail: React.FC = () => {
     const distance = mouseLocation - offset;
 
     const width = thumbnailRef.current.clientWidth;
-    const duration = video.get('duration');
+    const duration = end - start;
 
     const hoverTime = (distance / width) * duration;
 

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -99,6 +99,7 @@ const Tools: React.FC<props> = ({ setEdit }) => {
 
   const playPauseVideo = () => {
     if (!playing) {
+      // NOTE: playing을 바꿔서 slider의 useEffect를 통해 다시 렌더링하기 위함
       video.play();
       dispatch(play());
     } else {

--- a/client/src/store/originalVideo/actions.ts
+++ b/client/src/store/originalVideo/actions.ts
@@ -2,6 +2,7 @@ import {
   LoadMetadataAction,
   SetThumbnailsAction,
 } from '@/store/currentVideo/actions';
+import { CropConfirmAction } from '@/store/crop/actions';
 import {
   FETCH_START,
   SET_VIDEO,
@@ -45,5 +46,6 @@ export type OriginalVideoAction =
   | SetVideoAction
   | LoadMetadataAction
   | SetThumbnailsAction
+  | CropConfirmAction
   | ErrorAction
   | ResetAction;

--- a/client/src/store/originalVideo/reducer.ts
+++ b/client/src/store/originalVideo/reducer.ts
@@ -3,6 +3,7 @@ import {
   SET_VIDEO,
   LOAD_METADATA,
   SET_THUMBNAILS,
+  CROP_CONFIRM,
   RESET,
   ERROR,
 } from '../actionTypes';
@@ -12,7 +13,8 @@ enum Message {
   OK = '',
   DOWNLOADING = '서버에서 동영상을 다운로드하는 중...',
   LOADING = '동영상을 로드하는 중...',
-  PROCESSING = '편집한 동영상을 저장하는 중...',
+  PROCESSING = '썸네일을 다시 추출하는 중...',
+  SAVING = '편집한 동영상을 저장하는 중...',
   UPLOADING = '서버에 동영상을 업로드하는 중...',
   FAIL = '작업에 실패하였습니다.',
 }
@@ -58,6 +60,11 @@ export default (
       return {
         ...state,
         message: Message.OK,
+      };
+    case CROP_CONFIRM:
+      return {
+        ...state,
+        message: Message.PROCESSING,
       };
     case ERROR:
       return {


### PR DESCRIPTION
# 개요
- Crop 이후 slider / currentTime 로직 수정
- 오류 수정
  - start / end 이외의 영역에서 재생 가능했던 오류

# 체크리스트
- [x] Crop 이후 start / end를 고려한 Slider, CurrentTime, TimeZone 의 시간이 알맞게 표시된다.
- [x] Crop 이후 start / end를 고려하여 Slider click / hover 이벤트가 발생한다.
- [x] 다시 Crop을 적용한 경우 이전의 상태로 표시된다.
- [x] Start / End 영역을 벗어난 재생이 허용되지 않는다.
