### PR TITLE
[FE] video 회전, 변경 시 해상도 문제 해결 및 서명기능 추가

### DIFF
--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -199,6 +199,24 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
     }
   };
 
+  const handleSign = () => {
+    dispatchButtonData({ type: null });
+    dispatch(cropCancel());
+    if (isEdit === UP) setEdit(DOWN);
+    setToolType(toolType === ButtonTypes.sign ? null : ButtonTypes.sign);
+
+    const input = document.createElement('input');
+
+    input.addEventListener('change', e => {
+      const img = document.createElement('img');
+      img.src = URL.createObjectURL(e.target.files[0]);
+      webglController.setSign(img);
+    });
+
+    input.type = 'file';
+    input.click();
+  };
+
   return (
     <StyledDiv>
       <VideoTool
@@ -221,6 +239,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
             handleRotateReverse,
             handleRatio,
             handleCrop,
+            handleSign,
             hasEmptyVideo,
             toolType
           )}

--- a/client/src/components/organisms/Tools/buttonData.tsx
+++ b/client/src/components/organisms/Tools/buttonData.tsx
@@ -7,7 +7,7 @@ import {
   BsFillPauseFill,
   BsAspectRatio,
 } from 'react-icons/bs';
-import { RiScissorsLine } from 'react-icons/ri';
+import { RiScissorsLine, RiCopyrightLine } from 'react-icons/ri';
 import { MdScreenRotation } from 'react-icons/md';
 
 import size from '@/theme/sizes';
@@ -61,6 +61,7 @@ export const getEditToolData = (
   rotateReverse: () => void,
   ratio: () => void,
   crop: () => void,
+  sign: () => void,
   hasEmptyVideo: boolean,
   toolType: ButtonTypes
 ): button[] => [
@@ -98,6 +99,18 @@ export const getEditToolData = (
       <RiScissorsLine
         size={size.ICON_SIZE}
         color={toolType === ButtonTypes.crop ? color.PALE_PURPLE : undefined}
+      />
+    ),
+    disabled: hasEmptyVideo,
+  },
+  {
+    onClick: sign,
+    message: '서명',
+    type: toolType === ButtonTypes.sign ? 'selected' : 'transparent',
+    children: (
+      <RiCopyrightLine
+        size={size.ICON_SIZE}
+        color={toolType === ButtonTypes.sign ? color.PALE_PURPLE : undefined}
       />
     ),
     disabled: hasEmptyVideo,

--- a/client/src/components/organisms/Tools/reducer.tsx
+++ b/client/src/components/organisms/Tools/reducer.tsx
@@ -14,6 +14,7 @@ export enum ButtonTypes {
   crop = 'crop',
   videoEffect = 'videoEffect',
   ratio = 'ratio',
+  sign = 'sign',
 }
 
 export interface ButtonData {

--- a/client/src/webgl/webglController.ts
+++ b/client/src/webgl/webglController.ts
@@ -46,16 +46,24 @@ class WebglController {
     this.positions = this.init.positions.map(pair => [...pair]);
   }
 
+  swapWidthHeight = () => {
+    const temp = this.gl.canvas.width;
+    this.gl.canvas.width = this.gl.canvas.height;
+    this.gl.canvas.height = temp;
+  };
+
   rotateLeft90Degree = () => {
     // 0123 => 1230
     this.positions.push(this.positions.shift());
     this.buffers = this.initBuffers();
+    this.swapWidthHeight();
   };
 
   rotateRight90Degree = () => {
     // 0123 => 3012
     this.positions.unshift(this.positions.pop());
     this.buffers = this.initBuffers();
+    this.swapWidthHeight();
   };
 
   reverseUpsideDown = () => {
@@ -85,8 +93,8 @@ class WebglController {
 
   initCanvas = (videoWidth: string, videoHeight: string) => {
     const canvas = document.getElementById('glcanvas') as HTMLCanvasElement;
-    canvas.setAttribute('width', canvas.clientWidth.toString());
-    canvas.setAttribute('height', canvas.clientHeight.toString());
+    canvas.setAttribute('width', videoWidth);
+    canvas.setAttribute('height', videoHeight);
     const gl = (canvas.getContext('webgl', { alpha: false }) ||
       canvas.getContext('experimental-webgl', {
         alpha: false,
@@ -231,9 +239,12 @@ class WebglController {
     this.gl.clearColor(0.0, 0.0, 0.0, 1.0);
     this.gl.clearDepth(1.0);
     this.gl.enable(this.gl.DEPTH_TEST);
+    this.gl.enable(this.gl.BLEND);
     this.gl.depthFunc(this.gl.LEQUAL);
 
     this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);
+    this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
+    this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
 
     const zNear = 0.1;
     const zFar = 100.0;

--- a/client/src/webgl/webglController.ts
+++ b/client/src/webgl/webglController.ts
@@ -42,6 +42,8 @@ class WebglController {
     ],
   };
 
+  sign: HTMLImageElement;
+
   constructor() {
     this.positions = this.init.positions.map(pair => [...pair]);
   }
@@ -235,6 +237,76 @@ class WebglController {
     );
   };
 
+  setSign = sign => {
+    this.sign = sign;
+  };
+
+  drawSign = (modelViewMatrix, projectionMatrix, programInfo) => {
+    const reduce = 0.25;
+
+    mat4.scale(modelViewMatrix, modelViewMatrix, [
+      reduce,
+      reduce * (this.sign.height / this.sign.width),
+      1.0,
+    ]);
+
+    this.gl.useProgram(programInfo.program);
+
+    this.gl.uniformMatrix4fv(
+      programInfo.uniformLocations.projectionMatrix,
+      false,
+      projectionMatrix
+    );
+    this.gl.uniformMatrix4fv(
+      programInfo.uniformLocations.modelViewMatrix,
+      false,
+      modelViewMatrix
+    );
+
+    const texture2 = this.gl.createTexture();
+
+    this.gl.bindTexture(this.gl.TEXTURE_2D, texture2);
+
+    this.gl.uniform1i(programInfo.uniformLocations.uSampler, 0);
+
+    const level = 0;
+    const internalFormat = this.gl.RGBA;
+    const srcFormat = this.gl.RGBA;
+    const srcType = this.gl.UNSIGNED_BYTE;
+
+    this.gl.texImage2D(
+      this.gl.TEXTURE_2D,
+      level,
+      internalFormat,
+      srcFormat,
+      srcType,
+      this.sign
+    );
+
+    this.gl.texParameteri(
+      this.gl.TEXTURE_2D,
+      this.gl.TEXTURE_WRAP_S,
+      this.gl.CLAMP_TO_EDGE
+    );
+    this.gl.texParameteri(
+      this.gl.TEXTURE_2D,
+      this.gl.TEXTURE_WRAP_T,
+      this.gl.CLAMP_TO_EDGE
+    );
+    this.gl.texParameteri(
+      this.gl.TEXTURE_2D,
+      this.gl.TEXTURE_MIN_FILTER,
+      this.gl.LINEAR
+    );
+
+    {
+      const offset = 0;
+      const type = this.gl.UNSIGNED_SHORT;
+      const vertexCount = 6;
+      this.gl.drawElements(this.gl.TRIANGLES, vertexCount, type, offset);
+    }
+  };
+
   drawScene = (programInfo: ProgramInfo, texture: WebGLTexture) => {
     this.gl.clearColor(0.0, 0.0, 0.0, 1.0);
     this.gl.clearDepth(1.0);
@@ -320,6 +392,10 @@ class WebglController {
       const type = this.gl.UNSIGNED_SHORT;
       const offset = 0;
       this.gl.drawElements(this.gl.TRIANGLES, vertexCount, type, offset);
+    }
+
+    if (this.sign) {
+      this.drawSign(modelViewMatrix, projectionMatrix, programInfo);
     }
   };
 


### PR DESCRIPTION
# 개요
- video 회전, 변경 시 해상도 문제 해결
- 서명기능 추가 구현

# 체크리스트
- [x] 왼쪽, 오른쪽으로 회전을 하더라도 영상의 해상도가 유지된다
- [x] sign 버튼을 눌러 서명을 추가할 수 있다