### PR TITLE
[FE] Thumbnail 동기화 및 서버에서 영상 다운로드 구현

### DIFF
--- a/client/src/api/video.ts
+++ b/client/src/api/video.ts
@@ -1,4 +1,5 @@
 import { requestGET, requestPOST } from '@/api';
+import axios from 'axios';
 
 const VIDEO_BASE_URL = '/video';
 
@@ -6,6 +7,10 @@ const videoAPI = {
   upload: (formData: FormData) =>
     requestPOST(VIDEO_BASE_URL, formData, {}, true),
   getList: () => requestGET(`${VIDEO_BASE_URL}/list`),
+  download: url =>
+    axios.get(url, {
+      responseType: 'arraybuffer',
+    }),
 };
 
 export default videoAPI;

--- a/client/src/components/atoms/Button/Button.tsx
+++ b/client/src/components/atoms/Button/Button.tsx
@@ -39,18 +39,14 @@ interface Props {
   disabled: boolean;
 }
 
-const Button: React.FC<Props> = ({
-  children,
-  message,
-  onClick,
-  type,
-  disabled,
-}) => (
-  <StyledButton buttonType={type} onClick={onClick} disabled={disabled}>
-    {children}
-    {children && <br />}
-    {message}
-  </StyledButton>
+const Button: React.FC<Props> = React.memo(
+  ({ children, message, onClick, type, disabled }) => (
+    <StyledButton buttonType={type} onClick={onClick} disabled={disabled}>
+      {children}
+      {children && <br />}
+      {message}
+    </StyledButton>
+  )
 );
 
 export default Button;

--- a/client/src/components/atoms/ModalComponent/TextInput.tsx
+++ b/client/src/components/atoms/ModalComponent/TextInput.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from 'styled-components';
+import color from '@/theme/colors';
+
+import Props from './props';
+
+const StyledModalRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+`;
+
+const StyledInput = styled.input`
+  width: 75%;
+  padding: 0.5rem;
+  border-radius: 5px;
+  border: none;
+  box-shadow: 0 0 1px 2px rgba(255, 255, 255, 0.1);
+  background-color: ${color.MODAL};
+  color: ${color.WHITE};
+  outline: none;
+`;
+
+const StyledP = styled.p`
+  margin: 0;
+  width: 25%;
+  font-size: 12px;
+  text-align: center;
+`;
+
+const TextInput: React.FC<Props<string>> = ({
+  state: value,
+  setState: setValue,
+}) => {
+  const handleChange = ({ target }) => {
+    setValue(target.value);
+  };
+
+  return (
+    <StyledModalRow>
+      <StyledP>파일 이름 :</StyledP>
+      <StyledInput type="text" value={value} onChange={handleChange} />
+    </StyledModalRow>
+  );
+};
+
+export default TextInput;

--- a/client/src/components/atoms/ModalComponent/VideoItem.tsx
+++ b/client/src/components/atoms/ModalComponent/VideoItem.tsx
@@ -70,4 +70,4 @@ const VideoItem: React.FC<Props> = ({ video, handleCheck, selected }) => {
   );
 };
 
-export default VideoItem;
+export default React.memo(VideoItem);

--- a/client/src/components/atoms/ModalComponent/VideoItem.tsx
+++ b/client/src/components/atoms/ModalComponent/VideoItem.tsx
@@ -5,7 +5,7 @@ import { Video } from '@/store/video/actions';
 import color from '@/theme/colors';
 import { parseDateString } from '@/utils/time';
 
-const StyledDiv = styled.div`
+const StyledModalRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -21,7 +21,7 @@ const StyledDiv = styled.div`
   }
 `;
 
-const WrapperDiv = styled.div`
+const StyledDiv = styled.div`
   display: flex;
   width: 100%;
   align-items: center;
@@ -55,18 +55,18 @@ interface Props {
 
 const VideoItem: React.FC<Props> = ({ video, handleCheck, selected }) => {
   return (
-    <StyledDiv
+    <StyledModalRow
       onClick={() => handleCheck(video)}
       isChecked={selected === video}
     >
-      <WrapperDiv>
+      <StyledDiv>
         <Image src="https://user-images.githubusercontent.com/49153756/99666210-03b80600-2aae-11eb-95b9-f61f52694708.png" />
         <NameDiv>
           <Name>{video.name}</Name>
         </NameDiv>
         <Timestamp>{parseDateString(new Date(), video.updatedAt)}</Timestamp>
-      </WrapperDiv>
-    </StyledDiv>
+      </StyledDiv>
+    </StyledModalRow>
   );
 };
 

--- a/client/src/components/atoms/ModalComponent/VideoList.tsx
+++ b/client/src/components/atoms/ModalComponent/VideoList.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 
-import { fetchListStart } from '@/store/video/actions';
 import { getVideos } from '@/store/selectors';
+import { Video } from '@/store/video/actions';
 import color from '@/theme/colors';
+
+import Props from './props';
 import VideoItem from './VideoItem';
 
 const StyledDiv = styled.div`
@@ -28,16 +30,12 @@ const List = styled.div`
   overflow-y: auto;
 `;
 
-const VideoList: React.FC = () => {
-  const [selected, setSelected] = useState(null);
+const VideoList: React.FC<Props<Video>> = ({
+  state: selected,
+  setState: setSelected,
+}) => {
   const videos = useSelector(getVideos);
-  const dispatch = useDispatch();
-
   const handleCheck = video => setSelected(video);
-
-  useEffect(() => {
-    if (!videos) dispatch(fetchListStart());
-  }, [videos]);
 
   return (
     <StyledDiv>

--- a/client/src/components/atoms/ModalComponent/index.ts
+++ b/client/src/components/atoms/ModalComponent/index.ts
@@ -1,0 +1,3 @@
+export { default as TextInput } from './TextInput';
+export { default as VideoList } from './VideoList';
+export { default as ComponentProps } from './props';

--- a/client/src/components/atoms/ModalComponent/props.ts
+++ b/client/src/components/atoms/ModalComponent/props.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default interface Props<T> {
+  state: T;
+  setState: React.Dispatch<React.SetStateAction<T>>;
+}

--- a/client/src/components/atoms/Slider/Slider.tsx
+++ b/client/src/components/atoms/Slider/Slider.tsx
@@ -35,6 +35,7 @@ const StyledDiv = styled.div`
     css`
       ${moveSlider(location)} ${duration}s linear forwards;
     `};
+  z-index: 5;
 `;
 
 const Slider: React.FC<Props> = React.memo(({ thumbnailRef }) => {

--- a/client/src/components/atoms/VideoList/index.ts
+++ b/client/src/components/atoms/VideoList/index.ts
@@ -1,1 +1,0 @@
-export { default } from './VideoList';

--- a/client/src/components/molecules/FileInput/FileInput.tsx
+++ b/client/src/components/molecules/FileInput/FileInput.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import styled, { keyframes } from 'styled-components';
-
 import Modal from '@/components/molecules/Modal';
-import VideoList from '@/components/atoms/VideoList';
+import { VideoList } from '@/components/atoms/ModalComponent';
 import color from '@/theme/colors';
+import { Video } from '@/store/video/actions';
+import { fetchStart } from '@/store/originalVideo/actions';
 
 const slide = keyframes`
   from {
@@ -15,7 +17,6 @@ const slide = keyframes`
     opacity: 1;
   }
 `;
-
 const StyledDiv = styled.div`
   position: absolute;
   display: flex;
@@ -30,8 +31,8 @@ const StyledDiv = styled.div`
   animation: ${slide} 0.4s -0.1s ease-out;
   transform-origin: center center;
   width: 5rem;
+  z-index: 10;
 `;
-
 const FromLocal = styled.label`
   color: ${color.WHITE};
   font-size: 12px;
@@ -40,52 +41,47 @@ const FromLocal = styled.label`
   padding: 5px 16px;
   transition: 0.7s;
   border-radius: 5px 5px 0 0;
-
   &:hover {
     background-color: ${color.GRAY};
   }
 `;
-
 const FromServer = styled(FromLocal)`
   border-top: 1px solid ${color.BORDER};
   border-radius: 0 0 5px 5px;
 `;
-
 const StyledInput = styled.input`
   display: none;
 `;
-
 interface Props {
   handleChange: () => void;
 }
-
 const modalLayout = `
   top: 20vh;
   left: 35vw;
   width: 30vw;
   height: 60vh;
 `;
-
 const FileInput = React.forwardRef<HTMLInputElement, Props>(
   ({ handleChange }, forwardedRef) => {
     const [modalVisible, setModalVisible] = useState(false);
-
+    const dispatch = useDispatch();
     const handleClick = () => setModalVisible(true);
     const handleCancel = () => setModalVisible(false);
-    const handleConfirm = () => setModalVisible(false);
+    const handleConfirm = (video: Video) => {
+      dispatch(fetchStart(video));
+      setModalVisible(false);
+    };
 
-    const handleOverlay = () => setModalVisible(false);
     return (
       <StyledDiv>
         {modalVisible && (
           <Modal
             styleProps={modalLayout}
-            handleOverlay={handleOverlay}
-            handleButton1={handleCancel}
-            handleButton2={handleConfirm}
-            buttonMessage1="취소"
-            buttonMessage2="확인"
+            handleOverlay={handleCancel}
+            handleCancel={handleCancel}
+            handleConfirm={handleConfirm}
             component={VideoList}
+            initialState={null}
           />
         )}
         <FromLocal htmlFor="local">로컬</FromLocal>
@@ -100,5 +96,4 @@ const FileInput = React.forwardRef<HTMLInputElement, Props>(
     );
   }
 );
-
 export default FileInput;

--- a/client/src/components/molecules/HoverSlider/HoverSlider.tsx
+++ b/client/src/components/molecules/HoverSlider/HoverSlider.tsx
@@ -16,6 +16,7 @@ const StyledDiv = styled.div`
   width: 1px;
   border: solid 1px ${color.GRAY};
   height: 7rem;
+  z-index: 5;
 `;
 
 const WrapperDiv = styled.div`

--- a/client/src/components/molecules/Modal/Modal.tsx
+++ b/client/src/components/molecules/Modal/Modal.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import Button from '@/components/atoms/Button';
+import { ComponentProps } from '@/components/atoms/ModalComponent';
 import color from '@/theme/colors';
 
 const StyledModal = styled.div`
@@ -57,42 +58,42 @@ const StyledModalButtonRow = styled.div`
   }
 `;
 
-interface Props {
+interface Props<T> {
   styleProps: string;
   handleOverlay: () => void;
-  handleButton1: () => void;
-  handleButton2: () => void;
-  buttonMessage1: string;
-  buttonMessage2: string;
-  component: React.FC;
+  handleCancel: () => void;
+  handleConfirm: (state: T) => void;
+  component: React.FC<ComponentProps<T>>;
+  initialState: T;
 }
 
-const Modal: React.FC<Props> = ({
+const Modal: React.FC<Props<unknown>> = ({
   styleProps,
   handleOverlay,
-  handleButton1,
-  handleButton2,
-  buttonMessage1,
-  buttonMessage2,
+  handleCancel,
+  handleConfirm,
   component: Component,
+  initialState,
 }) => {
+  const [state, setState] = useState(initialState);
+
   return (
     <StyledModal>
       <StyledModalOverlay onClick={handleOverlay} />
       <StyledModalSection styleProps={styleProps}>
-        <Component />
+        <Component state={state} setState={setState} />
         <StyledModalButtonRow>
           <Button
             type="transparent"
-            message={buttonMessage1}
-            onClick={handleButton1}
+            message="취소"
+            onClick={handleCancel}
             disabled={false}
           />
           <Button
             type="transparent"
-            message={buttonMessage2}
-            onClick={handleButton2}
-            disabled={false}
+            message="확인"
+            onClick={() => handleConfirm(state)}
+            disabled={!state}
           />
         </StyledModalButtonRow>
       </StyledModalSection>

--- a/client/src/components/organisms/Header/Header.tsx
+++ b/client/src/components/organisms/Header/Header.tsx
@@ -15,6 +15,7 @@ import {
 
 import size from '@/theme/sizes';
 import Logo from '@/components/atoms/Logo';
+import { TextInput } from '@/components/atoms/ModalComponent';
 import ButtonGroup from '@/components/molecules/ButtonGroup';
 import Modal from '@/components/molecules/Modal';
 import color from '@/theme/colors';
@@ -109,31 +110,6 @@ const CancelConfirmStyle = `
   }
 `;
 
-const StyledModalRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-`;
-
-const StyledInput = styled.input`
-  width: 75%;
-  padding: 0.5rem;
-  border-radius: 5px;
-  border: none;
-  box-shadow: 0 0 1px 2px rgba(255, 255, 255, 0.1);
-  background-color: ${color.MODAL};
-  color: ${color.WHITE};
-  outline: none;
-`;
-
-const StyledP = styled.p`
-  margin: 0;
-  width: 25%;
-  font-size: 12px;
-  text-align: center;
-`;
-
 const modalLayout = `
 top: 35vh;
 left: 40vw;
@@ -143,13 +119,11 @@ height: 12vh;
 
 const Header: React.FC = () => {
   const dispatch = useDispatch();
-  const [complete, setComplete] = useState(false);
+  const [modalVisible, setModalVisible] = useState(false);
   const name = useSelector(getName);
   const hasEmptyVideo = !useSelector(getVisible);
   const isPrevDisabled = useSelector(getIsPrevDisabled);
   const isNextDisabled = useSelector(getIsNextDisabled);
-
-  const inputRef = useRef(null);
 
   const handlePrevious = () => {
     dispatch(undo());
@@ -162,33 +136,13 @@ const Header: React.FC = () => {
   };
   const handleCancel = () => dispatch(reset());
 
-  const handleModalConfirm = () => {
-    dispatch(encodeStart(inputRef.current.value));
-    setComplete(false);
+  const handleModalConfirm = fileName => {
+    dispatch(encodeStart(fileName));
+    setModalVisible(false);
   };
 
-  const handleModalCancel = () => setComplete(false);
-  const handleComplete = () => setComplete(true);
-
-  const modalInnerComponent = () => {
-    const [value, setValue] = useState(name);
-
-    const handleVideoNameChange = ({ target }) => {
-      setValue(target.value);
-    };
-
-    return (
-      <StyledModalRow>
-        <StyledP>파일 이름 :</StyledP>
-        <StyledInput
-          ref={inputRef}
-          type="text"
-          value={value}
-          onChange={handleVideoNameChange}
-        />
-      </StyledModalRow>
-    );
-  };
+  const handleModalCancel = () => setModalVisible(false);
+  const handleComplete = () => setModalVisible(true);
 
   return (
     <StyledHeader>
@@ -213,15 +167,14 @@ const Header: React.FC = () => {
           hasEmptyVideo
         )}
       />
-      {complete && (
+      {modalVisible && (
         <Modal
           styleProps={modalLayout}
           handleOverlay={handleModalCancel}
-          handleButton1={handleModalCancel}
-          handleButton2={handleModalConfirm}
-          buttonMessage1="취소"
-          buttonMessage2="확인"
-          component={modalInnerComponent}
+          handleCancel={handleModalCancel}
+          handleConfirm={handleModalConfirm}
+          component={TextInput}
+          initialState={name}
         />
       )}
     </StyledHeader>

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -210,9 +210,9 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
 
     const input = document.createElement('input');
 
-    input.addEventListener('change', e => {
+    input.addEventListener('change', ({ target }) => {
       const img = document.createElement('img');
-      img.src = URL.createObjectURL(e.target.files[0]);
+      img.src = URL.createObjectURL((target as HTMLInputElement).files[0]);
       webglController.setSign(img);
     });
 

--- a/client/src/pages/edit.tsx
+++ b/client/src/pages/edit.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
 import TimeLine from '@/components/organisms/TimeLine';
@@ -7,7 +7,8 @@ import Header from '@/components/organisms/Header';
 import Tools from '@/components/organisms/Tools';
 import VideoContainer from '@/components/organisms/VideoContainer';
 import Loading from '@/components/atoms/Loading';
-import { getMessage } from '@/store/selectors';
+import { fetchListStart } from '@/store/video/actions';
+import { getMessage, getVideos } from '@/store/selectors';
 
 const StyledDiv = styled.div`
   display: flex;
@@ -21,7 +22,13 @@ const BottomDiv = styled.div``;
 
 const EditPage: React.FC = () => {
   const message = useSelector(getMessage);
+  const videos = useSelector(getVideos);
+  const dispatch = useDispatch();
   const [isEdit, setEdit] = useState('');
+
+  useEffect(() => {
+    if (!videos) dispatch(fetchListStart());
+  }, [videos]);
 
   return (
     <StyledDiv>

--- a/client/src/store/actionTypes.ts
+++ b/client/src/store/actionTypes.ts
@@ -30,7 +30,9 @@ export const LOGOUT = 'LOGOUT';
 
 // history
 export const UNDO = 'history/UNDO';
+export const UNDO_SUCCESS = 'history/UNDO_SUCCESS';
 export const REDO = 'history/REDO';
+export const REDO_SUCCESS = 'history/REDO_SUCCESS';
 export const CLEAR = 'history/CLEAR';
 export const APPLY_EFFECT = 'history/APPLY_EFFECT';
 export const APPLY_CROP = 'history/APPLY_CROP';

--- a/client/src/store/history/actions.ts
+++ b/client/src/store/history/actions.ts
@@ -1,6 +1,8 @@
 import {
   UNDO,
+  UNDO_SUCCESS,
   REDO,
+  REDO_SUCCESS,
   CLEAR,
   APPLY_EFFECT,
   APPLY_CROP,
@@ -50,8 +52,24 @@ export const undo = () => ({
   type: UNDO,
 });
 
+export const undoSuccess = (index, reverseEffect) => ({
+  type: UNDO_SUCCESS,
+  payload: {
+    index,
+    reverseEffect,
+  },
+});
+
 export const redo = () => ({
   type: REDO,
+});
+
+export const redoSuccess = (index, reverseEffect) => ({
+  type: REDO_SUCCESS,
+  payload: {
+    index,
+    reverseEffect,
+  },
 });
 
 export const clear = () => ({
@@ -71,12 +89,20 @@ export const applyCrop = (thumbnails: Thumbnails, interval: Interval) => ({
   },
 });
 
-export type HistoryUndoAction = {
-  type: typeof UNDO;
+export type HistoryUndoSuccessAction = {
+  type: typeof UNDO_SUCCESS;
+  payload: {
+    index: number;
+    reverseEffect: Effect;
+  };
 };
 
-export type HistoryRedoAction = {
-  type: typeof REDO;
+export type HistoryRedoSuccessAction = {
+  type: typeof REDO_SUCCESS;
+  payload: {
+    index: number;
+    reverseEffect: Effect;
+  };
 };
 
 export type HistoryClearAction = {
@@ -97,8 +123,8 @@ export type HistoryApplyCropAction = {
 };
 
 export type HistoryAction =
-  | HistoryUndoAction
-  | HistoryRedoAction
+  | HistoryUndoSuccessAction
+  | HistoryRedoSuccessAction
   | HistoryClearAction
   | HistoryApplyEffectAction
   | HistoryApplyCropAction

--- a/client/src/store/history/reducer.ts
+++ b/client/src/store/history/reducer.ts
@@ -1,7 +1,7 @@
 import { RATIO, INVERSE } from '@/webgl/webglController';
 import {
-  UNDO,
-  REDO,
+  UNDO_SUCCESS,
+  REDO_SUCCESS,
   APPLY_EFFECT,
   RESET,
   CLEAR,
@@ -32,12 +32,12 @@ const getStatusFromEffect = (status: Status, effect: Effect) => {
     case Effect.RotateClockwise:
       return {
         ...status,
-        rotation: (status.rotation + 90) % 360,
+        rotation: (status.rotation + (status.flipped ? 270 : 90)) % 360,
       };
     case Effect.RotateCounterClockwise:
       return {
         ...status,
-        rotation: (status.rotation + 270) % 360,
+        rotation: (status.rotation + (status.flipped ? 90 : 270)) % 360,
       };
     case Effect.FlipHorizontal:
       return {
@@ -73,15 +73,12 @@ export default (
   const logs = state.logs.slice(isFull ? 1 : 0, state.index);
 
   switch (action.type) {
-    case UNDO:
+    case UNDO_SUCCESS: // fallthrough
+    case REDO_SUCCESS:
       return {
         ...state,
-        index: state.index === 0 ? state.index : state.index - 1,
-      };
-    case REDO:
-      return {
-        ...state,
-        index: state.index === MAX_HISTORY ? state.index : state.index + 1,
+        index: action.payload.index,
+        status: getStatusFromEffect(state.status, action.payload.reverseEffect),
       };
     case APPLY_EFFECT:
       return {

--- a/client/src/store/history/sagas.ts
+++ b/client/src/store/history/sagas.ts
@@ -28,53 +28,49 @@ function* updateThumbnailsHistory(thumbnails: string[], { start, end }) {
   try {
     yield put(setThumbnails(thumbnails));
     yield put(updateStartEnd(start, end));
-    yield put(moveTo(start));
     yield call(video.setCurrentTime, start);
+    yield put(moveTo(start));
   } catch (err) {
     console.log(err);
     yield put(error());
   }
 }
 
-const effectMapper = (effect: Effect) => {
-  switch (effect) {
-    case Effect.RotateClockwise:
-      return {
-        apply: webglController.rotateRight90Degree,
-        rollback: webglController.rotateLeft90Degree,
-      };
-    case Effect.RotateCounterClockwise:
-      return {
-        apply: webglController.rotateLeft90Degree,
-        rollback: webglController.rotateRight90Degree,
-      };
-    case Effect.FlipHorizontal:
-      return {
-        apply: webglController.reverseSideToSide,
-        rollback: webglController.reverseUpsideDown,
-      };
-    case Effect.FlipVertical:
-      return {
-        apply: webglController.reverseSideToSide,
-        rollback: webglController.reverseUpsideDown,
-      };
-    case Effect.Enlarge:
-      return {
-        apply: webglController.enlarge,
-        rollback: webglController.reduce,
-      };
-    case Effect.Reduce:
-      return {
-        apply: webglController.reduce,
-        rollback: webglController.enlarge,
-      };
-    default:
-      return {};
-  }
+const effectMapper = {
+  [Effect.RotateClockwise]: {
+    apply: webglController.rotateRight90Degree,
+    rollback: webglController.rotateLeft90Degree,
+    reverseEffect: Effect.RotateCounterClockwise,
+  },
+  [Effect.RotateCounterClockwise]: {
+    apply: webglController.rotateLeft90Degree,
+    rollback: webglController.rotateRight90Degree,
+    reverseEffect: Effect.RotateClockwise,
+  },
+  [Effect.FlipHorizontal]: {
+    apply: webglController.reverseUpsideDown,
+    rollback: webglController.reverseUpsideDown,
+    reverseEffect: Effect.FlipHorizontal,
+  },
+  [Effect.FlipVertical]: {
+    apply: webglController.reverseSideToSide,
+    rollback: webglController.reverseSideToSide,
+    reverseEffect: Effect.FlipVertical,
+  },
+  [Effect.Enlarge]: {
+    apply: webglController.enlarge,
+    rollback: webglController.reduce,
+    reverseEffect: Effect.Reduce,
+  },
+  [Effect.Reduce]: {
+    apply: webglController.reduce,
+    rollback: webglController.enlarge,
+    reverseEffect: Effect.Enlarge,
+  },
 };
 
 function* controlWebgl(action) {
-  yield call(effectMapper(action.payload.effect).apply);
+  yield call(effectMapper[action.payload.effect].apply);
 }
 
 function* undoEffect(action) {

--- a/client/src/store/originalVideo/actions.ts
+++ b/client/src/store/originalVideo/actions.ts
@@ -2,7 +2,7 @@ import {
   LoadMetadataAction,
   SetThumbnailsAction,
 } from '@/store/currentVideo/actions';
-import { UploadSuccessAction } from '@/store/video/actions';
+import { Video, UploadSuccessAction } from '@/store/video/actions';
 import { CropConfirmAction } from '@/store/crop/actions';
 import {
   FETCH_START,
@@ -16,7 +16,7 @@ import {
   ErrorAction,
 } from '../actionTypes';
 
-// TODO: export const fetchStart = () => ({ type: FETCH_START });
+export const fetchStart = video => ({ type: FETCH_START, payload: video });
 
 export const setVideo = (video: File, URL: string) => ({
   type: SET_VIDEO,
@@ -44,6 +44,7 @@ export const uploadStart = file => ({
 
 type FetchStartAction = {
   type: typeof FETCH_START;
+  payload: Video;
 };
 
 type SetVideoAction = {

--- a/client/src/store/originalVideo/sagas.ts
+++ b/client/src/store/originalVideo/sagas.ts
@@ -47,6 +47,11 @@ export function* deleteSrc() {
   yield call(video.revoke);
 }
 
+export function* clearErrorLoading() {
+  yield call(() => new Promise(resolve => setTimeout(resolve, TIMEOUT)));
+  yield put(setThumbnails([]));
+}
+
 function waitMetadataLoading(objectURL) {
   return new Promise<number>((resolve, reject) => {
     const timer = setTimeout(reject, TIMEOUT, 'loading metadata timeout');

--- a/client/src/store/originalVideo/sagas.ts
+++ b/client/src/store/originalVideo/sagas.ts
@@ -4,10 +4,16 @@ import video from '@/video/video';
 import webglController from '@/webgl/webglController';
 import videoAPI from '@/api/video';
 
-import { loadMetadata, uploadStart, EncodeStartAction } from './actions';
+import {
+  setVideo,
+  loadMetadata,
+  uploadStart,
+  EncodeStartAction,
+} from './actions';
 import { setThumbnails } from '../currentVideo/actions';
 import { uploadSuccess } from '../video/actions';
 import {
+  FETCH_START,
   SET_VIDEO,
   ENCODE_START,
   UPLOAD_START,
@@ -17,6 +23,24 @@ import {
 import { getFile } from '../selectors';
 
 const TIMEOUT = 5_000;
+
+function* downloadFromServer(action) {
+  try {
+    const { data } = yield call(videoAPI.download, action.payload.video);
+    const file = new File([data], action.payload.name, {
+      type: 'video/mp4',
+    });
+    const url = URL.createObjectURL(file);
+    yield put(setVideo(file, url));
+  } catch (err) {
+    console.log(err);
+    yield put(error());
+  }
+}
+
+export function* watchFetchStart() {
+  yield takeLatest(FETCH_START, downloadFromServer);
+}
 
 export function* deleteSrc() {
   yield call(webglController.reset);

--- a/client/src/store/sagas.ts
+++ b/client/src/store/sagas.ts
@@ -1,21 +1,28 @@
 import { all, call, takeEvery } from 'redux-saga/effects';
 import {
+  watchFetchStart,
   watchSetVideo,
   watchEncodeStart,
   watchUploadStart,
   deleteSrc,
+  clearErrorLoading,
 } from '@/store/originalVideo/sagas';
 import watchFetchListStart from '@/store/video/sagas';
 import watchCrop from '@/store/crop/sagas';
 import { watchApplyEffect, watchHistory } from '@/store/history/sagas';
-import { RESET } from './actionTypes';
+import { ERROR, RESET } from './actionTypes';
 
 function* watchReset() {
   yield takeEvery(RESET, deleteSrc);
 }
 
+function* watchError() {
+  yield takeEvery(ERROR, clearErrorLoading);
+}
+
 export default function* rootSaga() {
   yield all([
+    watchFetchStart(),
     watchSetVideo(),
     watchEncodeStart(),
     watchUploadStart(),
@@ -24,5 +31,6 @@ export default function* rootSaga() {
     watchFetchListStart(),
     watchApplyEffect(),
     watchHistory(),
+    watchError(),
   ]);
 }

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -71,3 +71,8 @@ export const getIsNextDisabled = (state: RootState) => {
   const { index, logs } = state.history;
   return index === logs.length;
 };
+
+export const getStatus = (state: RootState) => {
+  const { status } = state.history;
+  return status;
+};

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -72,7 +72,4 @@ export const getIsNextDisabled = (state: RootState) => {
   return index === logs.length;
 };
 
-export const getStatus = (state: RootState) => {
-  const { status } = state.history;
-  return status;
-};
+export const getStatus = (state: RootState) => state.history.status;

--- a/server/bin/www.ts
+++ b/server/bin/www.ts
@@ -7,19 +7,22 @@ import path from 'path';
 import App from '@/main/App';
 
 const port: number = Number(process.env.PORT) || 3000;
-const options = {
-  key: fs.readFileSync(path.resolve(__dirname, '../cert/private.key')),
-  cert: fs.readFileSync(path.resolve(__dirname, '../cert/certificate.crt')),
-  ca: fs.readFileSync(path.resolve(__dirname, '../cert/ca_bundle.crt'))
-};
 
+if (process.env.NODE_ENV === 'production') {
+  const options = {
+    key: fs.readFileSync(path.resolve(__dirname, '../cert/private.key')),
+    cert: fs.readFileSync(path.resolve(__dirname, '../cert/certificate.crt')),
+    ca: fs.readFileSync(path.resolve(__dirname, '../cert/ca_bundle.crt')),
+  };
 
-if (process.env.NODE_ENV === 'production')
-  https.createServer(options, App).listen(port, () =>
-    console.log(`Express https server listening at ${port}`)
-  ).on('error', err => console.error(err));
-else
-  http.createServer(App).listen(port, () =>
-    console.log(`Express http server listening at ${port}`)
-  ).on('error', err => console.error(err));
-
+  https
+    .createServer(options, App)
+    .listen(port, () =>
+      console.log(`Express https server listening at ${port}`)
+    )
+    .on('error', err => console.error(err));
+} else
+  http
+    .createServer(App)
+    .listen(port, () => console.log(`Express http server listening at ${port}`))
+    .on('error', err => console.error(err));


### PR DESCRIPTION
# 개요
- Thumbnail과 canvas의 회전/반전, 확대/축소 상태 동기화
- History store에서 status update 제대로 안되는 것 수정
- 서버에서 영상 선택 후, 해당 동영상을 편집가능하도록 다운로드
- Modal 구조 리팩토링

# 체크리스트
- [x] Thumbnail이 회전/반전이 가능하다
- [x] Thumbnail이 확대/축소 가능하다
- [x] 불러오기 버튼에서 서버를 선택한 후에 영상을 고르면 해당 영상이 편집가능하도록 캔버스에 보여진다
- [x] 서버에 업로드할 때 사용자가 입력한 이름으로 업로드된다.
