### PR TITLE
[FE] mp4-h264를 활용한 영상 인코딩 및 서명 기능 및 각종 오류 수정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1322,6 +1322,11 @@
         }
       }
     },
+    "@open-wc/webpack-import-meta-loader": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@open-wc/webpack-import-meta-loader/-/webpack-import-meta-loader-0.4.7.tgz",
+      "integrity": "sha512-F3d1EHRckk2+ZpgEEAgVITp8BU9DYLBhKOhNMREeQ1BwILRIhrt+V1bebpnd0Mz595jzd7Yh1wSibLsXibkCpg=="
+    },
     "@redux-saga/core": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
@@ -6177,6 +6182,11 @@
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
       }
+    },
+    "mp4-h264": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mp4-h264/-/mp4-h264-1.0.4.tgz",
+      "integrity": "sha512-6SARrl3WX6x7lSOyDKKnvXz0No29a5H/UIlMRGRbWO+sRZwjBq8aTe9d2tMbdrV3SwUEXmKLXp8YJuWXdoBldA=="
     },
     "ms": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -50,11 +50,13 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@open-wc/webpack-import-meta-loader": "^0.4.7",
     "@types/react-redux": "^7.1.11",
     "axios": "^0.21.0",
     "clean-webpack-plugin": "^3.0.0",
     "gl-matrix": "^3.3.0",
     "html-webpack-plugin": "^4.5.0",
+    "mp4-h264": "^1.0.4",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-icons": "^3.11.0",

--- a/client/src/components/atoms/ModalComponent/VideoList.tsx
+++ b/client/src/components/atoms/ModalComponent/VideoList.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getVideos } from '@/store/selectors';
 import { Video } from '@/store/video/actions';
@@ -43,7 +44,7 @@ const VideoList: React.FC<Props<Video>> = ({
       <List>
         {videos?.map(video => (
           <VideoItem
-            key={video.name}
+            key={uuidv4()}
             video={video}
             handleCheck={handleCheck}
             selected={selected}

--- a/client/src/components/atoms/Range/Range.tsx
+++ b/client/src/components/atoms/Range/Range.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import webglController from '@/webgl/webglController';
+
+const StyledInput = styled.input`
+  position: absolute;
+  left: 3rem;
+  top: 1rem;
+  transform: rotate(-90deg);
+  width: 4rem;
+  box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.3);
+`;
+
+const Range: React.FC = () => {
+  const [value, setValue] = useState(25);
+
+  const handleChange = useCallback(e => {
+    const currentValue = e.target.value;
+    webglController.setSignRatio(currentValue);
+    setValue(currentValue);
+  }, []);
+
+  return (
+    <StyledInput
+      type="range"
+      min="10"
+      max="50"
+      value={value}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default Range;

--- a/client/src/components/atoms/Range/index.ts
+++ b/client/src/components/atoms/Range/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Range';

--- a/client/src/components/molecules/CropLayer/CropLayer.tsx
+++ b/client/src/components/molecules/CropLayer/CropLayer.tsx
@@ -25,7 +25,7 @@ const CropLayerDiv = styled.div`
   top: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
+  z-index: 7;
 `;
 
 const Overlay = styled.div<OverlayProps>`

--- a/client/src/components/molecules/FileInput/FileInput.tsx
+++ b/client/src/components/molecules/FileInput/FileInput.tsx
@@ -31,7 +31,7 @@ const StyledDiv = styled.div`
   animation: ${slide} 0.4s -0.1s ease-out;
   transform-origin: center center;
   width: 5rem;
-  z-index: 10;
+  z-index: 5;
 `;
 const FromLocal = styled.label`
   color: ${color.WHITE};

--- a/client/src/components/molecules/Thumbnail/Thumbnail.tsx
+++ b/client/src/components/molecules/Thumbnail/Thumbnail.tsx
@@ -35,7 +35,7 @@ const StyledImg = styled.img`
   width: 100%;
   height: 50px;
   transform: scale(${props => props.status.scale})
-    scaleX(${props => (props.status.flipped ? -1 : 1)})
+    scaleY(${props => (props.status.flipped ? -1 : 1)})
     rotate(${props => props.status.rotation}deg);
 `;
 const ImageDiv = styled.div`
@@ -63,6 +63,7 @@ const Thumbnail: React.FC = () => {
   const { isCrop, duration } = useSelector(getIsCropAndDuration, shallowEqual);
   const { start, end } = useSelector(getStartEnd, shallowEqual);
   const status = useSelector(getStatus);
+
   const [time, setTime] = useState(0);
   const dispatch = useDispatch();
 

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -197,6 +197,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
 
   const openSubtool = (type: ButtonTypes, payload: (() => void)[]) => {
     removeSignEvent();
+    webglController.setSignEdit(false);
     if (type !== ButtonTypes.crop) dispatch(cropCancel());
 
     setEdit(UP);
@@ -237,8 +238,8 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
       rotateReverse: [
         () => dispatch(applyEffect(Effect.RotateCounterClockwise)),
         () => dispatch(applyEffect(Effect.RotateClockwise)),
-        () => dispatch(applyEffect(Effect.FlipHorizontal)),
         () => dispatch(applyEffect(Effect.FlipVertical)),
+        () => dispatch(applyEffect(Effect.FlipHorizontal)),
       ],
       ratio: [
         () => dispatch(applyEffect(Effect.Enlarge)),
@@ -277,9 +278,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
 
       glCanvas.addEventListener('mousedown', handleCanvasMouseDown);
       glCanvas.addEventListener('mouseup', handleCanvasMouseUp);
-      if (webglController.sign) {
-        webglController.setSignEdit(true);
-      }
+      if (webglController.sign) webglController.setSignEdit(true);
     } else closeSubtool();
   };
 

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -215,7 +215,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
     closeSubtool();
   }, [dispatch]);
 
-  const handleSignFetch = useCallback(() => {
+  const handleSignUpload = useCallback(() => {
     input.type = 'file';
     input.addEventListener('change', handleInputChange);
     input.click();
@@ -246,7 +246,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
         () => dispatch(applyEffect(Effect.Reduce)),
       ],
       crop: [/* handleCropManually , */ handleCropConfirm, handleCropCancel],
-      sign: [handleSignFetch, handleSignConfirm, handleSignCancel],
+      sign: [handleSignUpload, handleSignConfirm, handleSignCancel],
     }),
     []
   );

--- a/client/src/components/organisms/Tools/reducer.tsx
+++ b/client/src/components/organisms/Tools/reducer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { BsTerminal, BsCheck, BsX } from 'react-icons/bs';
+import { BsTerminal, BsCheck, BsX, BsUpload } from 'react-icons/bs';
+import { GoTrashcan } from 'react-icons/go';
 import {
   MdRotateLeft,
   MdRotateRight,
@@ -53,6 +54,14 @@ const ratioChildrens = [
   <MdZoomOut size={size.ICON_SIZE} />,
 ];
 
+// sign
+const signMessages = ['불러오기', '확인', '삭제'];
+const signChildrens = [
+  <BsUpload size={size.ICON_SIZE} />,
+  <BsCheck size={size.ICON_SIZE} />,
+  <GoTrashcan size={size.ICON_SIZE} />,
+];
+
 export const initialData: ButtonData = {
   onClicks: [],
   messages: [],
@@ -82,6 +91,13 @@ export default (state: ButtonData, action: ButtonDataAction): ButtonData => {
         messages: ratioMessages,
         type: 'transparent',
         childrens: ratioChildrens,
+      };
+    case ButtonTypes.sign:
+      return {
+        onClicks: action.payload,
+        messages: signMessages,
+        type: 'transparent',
+        childrens: signChildrens,
       };
     default:
       return initialData;

--- a/client/src/store/history/actions.ts
+++ b/client/src/store/history/actions.ts
@@ -52,7 +52,7 @@ export const undo = () => ({
   type: UNDO,
 });
 
-export const undoSuccess = (index, reverseEffect) => ({
+export const undoSuccess = (index, reverseEffect = undefined) => ({
   type: UNDO_SUCCESS,
   payload: {
     index,
@@ -64,7 +64,7 @@ export const redo = () => ({
   type: REDO,
 });
 
-export const redoSuccess = (index, reverseEffect) => ({
+export const redoSuccess = (index, reverseEffect = undefined) => ({
   type: REDO_SUCCESS,
   payload: {
     index,

--- a/client/src/store/history/sagas.ts
+++ b/client/src/store/history/sagas.ts
@@ -51,13 +51,13 @@ const effectMapper = (effect: Effect) => {
       };
     case Effect.FlipHorizontal:
       return {
-        apply: webglController.reverseSideToSide,
+        apply: webglController.reverseUpsideDown,
         rollback: webglController.reverseUpsideDown,
       };
     case Effect.FlipVertical:
       return {
         apply: webglController.reverseSideToSide,
-        rollback: webglController.reverseUpsideDown,
+        rollback: webglController.reverseSideToSide,
       };
     case Effect.Enlarge:
       return {

--- a/client/src/store/originalVideo/actions.ts
+++ b/client/src/store/originalVideo/actions.ts
@@ -8,10 +8,8 @@ import {
   FETCH_START,
   SET_VIDEO,
   LOAD_METADATA,
-  LOAD_SUCCESS,
   ENCODE_START,
   UPLOAD_START,
-  UPLOAD_SUCCESS,
   ResetAction,
   ErrorAction,
 } from '../actionTypes';

--- a/client/src/store/originalVideo/sagas.ts
+++ b/client/src/store/originalVideo/sagas.ts
@@ -1,6 +1,7 @@
 import { put, call, takeLatest, select } from 'redux-saga/effects';
 
 import video from '@/video/video';
+import encodeVideo from '@/video/encoding';
 import webglController from '@/webgl/webglController';
 import videoAPI from '@/api/video';
 
@@ -14,7 +15,7 @@ import {
   error,
   reset,
 } from '../actionTypes';
-import { getFile } from '../selectors';
+import { getFile, getStartEnd } from '../selectors';
 
 const TIMEOUT = 5_000;
 
@@ -64,11 +65,9 @@ export function* watchSetVideo() {
 
 function* encode(action: EncodeStartAction) {
   try {
-    const temp = yield select(getFile);
-    const file = yield call(
-      name => new Promise(resolve => setTimeout(() => resolve(temp), TIMEOUT)),
-      action.payload.name
-    ); // FIXME: do encoding here
+    const { start, end } = yield select(getStartEnd);
+    const file = yield call(encodeVideo, start, end);
+
     yield put(uploadStart(file));
   } catch (err) {
     console.log(err);

--- a/client/src/store/originalVideo/sagas.ts
+++ b/client/src/store/originalVideo/sagas.ts
@@ -22,6 +22,7 @@ import {
   reset,
 } from '../actionTypes';
 import { getStartEnd } from '../selectors';
+import { clear } from '../history/actions';
 
 const TIMEOUT = 5_000;
 
@@ -75,13 +76,13 @@ function* load(action) {
   try {
     const duration = yield call(waitMetadataLoading, action.payload.URL);
     yield put(loadMetadata(duration));
-
     const thumbnails: string[] = yield call(video.makeThumbnails, 0, duration);
 
     yield call(webglController.main);
     yield call(webglController.clear);
 
     yield put(setThumbnails(thumbnails));
+    yield put(clear());
   } catch (err) {
     console.log(err);
     yield put(error());
@@ -95,7 +96,7 @@ export function* watchSetVideo() {
 const downloadFile = (url, filename) => {
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${filename}.mp4`;
+  a.download = filename;
   a.click();
   a.remove();
   URL.revokeObjectURL(url);

--- a/client/src/theme/globalStyle.tsx
+++ b/client/src/theme/globalStyle.tsx
@@ -20,6 +20,31 @@ const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: border-box;
   }
+  input[type=range] {
+  -webkit-appearance: none;
+  cursor: pointer;
+  color: ${color.PURPLE};
+  background: ${color.LIGHT_PURPLE};
+  height: 0.5rem;
+  border-radius: 5px;
+}
+
+input[type=range]:focus {
+  outline: none; 
+}
+input[type=range]::-webkit-slider-thumb { 
+  -webkit-appearance: none; 
+  background: ${color.WHITE}; 
+  cursor: pointer; 
+  border: none; 
+  height: 0.8rem; width: 0.8rem; 
+  border-radius: 40%; 
+}
+
+input[type=range]::-webkit-slider-thumb:hover { 
+  transform: scale(1.2, 1.3);
+  box-shadow: 0 0 5px 2px rgba(255, 255, 255, 0.5);
+}
 `;
 
 export default GlobalStyle;

--- a/client/src/video/encoding.ts
+++ b/client/src/video/encoding.ts
@@ -1,0 +1,73 @@
+import loadEncoder from 'mp4-h264';
+import webglController from '@/webgl/webglController';
+import video from '.';
+
+const framerate = 30;
+
+interface VideoElement extends HTMLVideoElement {
+  captureStream(): MediaStream;
+}
+
+const frameCount: number = 0;
+
+const init = () => {
+  const track = (video.getVideo() as VideoElement)
+    .captureStream()
+    .getVideoTracks()[0];
+  track.applyConstraints({ advanced: [{ frameRate: framerate }] });
+
+  const videoTrackReader = new VideoTrackReader(track);
+  return { videoTrackReader };
+};
+
+export default async (start, end) => {
+  const { videoTrackReader } = init();
+
+  const Encoder = await loadEncoder();
+
+  const {
+    drawingBufferWidth: width,
+    drawingBufferHeight: height,
+  } = webglController.getDrawingBufferWidthHeight();
+
+  const encoder = Encoder.create({
+    width,
+    height,
+    fps: 30,
+  });
+
+  const applyEffect = async frame => {
+    const image = await frame.createImageBitmap();
+    const pixels = webglController.getPixelsFromImage(image);
+    encoder.encodeRGB(pixels);
+    frame.destroy();
+  };
+
+  const duration = (end - start) * 1e6; // seconds -> microseconds
+  const finished = frame => frame.timestamp > duration;
+
+  return new Promise(resolve => {
+    const handleFrame = frame => {
+      if (finished(frame)) {
+        videoTrackReader.stop();
+        video.pause();
+        const mp4 = encoder.end();
+        resolve(new Blob([mp4], { type: 'video/mp4' }));
+      } else {
+        applyEffect(frame);
+      }
+    };
+
+    const addEventListenerThenPlay = () => {
+      video.play();
+      video.addEventListener(
+        'play',
+        () => videoTrackReader.start(handleFrame),
+        { once: true }
+      );
+    };
+
+    video.setCurrentTime(start);
+    addEventListenerThenPlay();
+  });
+};

--- a/client/src/video/encoding.ts
+++ b/client/src/video/encoding.ts
@@ -2,26 +2,38 @@ import loadEncoder from 'mp4-h264';
 import webglController from '@/webgl/webglController';
 import video from '.';
 
+interface TrackReader {
+  new (track: MediaStreamTrack): {
+    start: Function;
+    stop: Function;
+  };
+}
+
+interface WebCodecs {
+  VideoTrackReader: TrackReader;
+}
+
 const framerate = 30;
 
 interface VideoElement extends HTMLVideoElement {
   captureStream(): MediaStream;
 }
 
-const frameCount: number = 0;
-
 const init = () => {
-  const track = (video.getVideo() as VideoElement)
+  const track: MediaStreamTrack = (video.getVideo() as VideoElement)
     .captureStream()
     .getVideoTracks()[0];
   track.applyConstraints({ advanced: [{ frameRate: framerate }] });
 
-  const videoTrackReader = new VideoTrackReader(track);
-  return { videoTrackReader };
+  const videoTrackReader = new ((window as unknown) as WebCodecs).VideoTrackReader(
+    track
+  );
+
+  return videoTrackReader;
 };
 
 export default async (start, end) => {
-  const { videoTrackReader } = init();
+  const videoTrackReader = init();
 
   const Encoder = await loadEncoder();
 

--- a/client/src/video/encoding.ts
+++ b/client/src/video/encoding.ts
@@ -70,16 +70,10 @@ export default async (start, end) => {
       }
     };
 
-    const addEventListenerThenPlay = () => {
-      video.play();
-      video.addEventListener(
-        'play',
-        () => videoTrackReader.start(handleFrame),
-        { once: true }
-      );
-    };
-
     video.setCurrentTime(start);
-    addEventListenerThenPlay();
+    video.play();
+    video.addEventListener('play', () => videoTrackReader.start(handleFrame), {
+      once: true,
+    });
   });
 };

--- a/client/src/webgl/webglConfig.ts
+++ b/client/src/webgl/webglConfig.ts
@@ -1,0 +1,173 @@
+import video from '@/video';
+import vertexShaderSource from './vertexShaderSource';
+import fragmentShaderSource from './fragmentShaderSource';
+
+const initTexture = (gl: WebGLRenderingContext) => {
+  const texture = gl.createTexture();
+
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+
+  const level = 0;
+  const internalFormat = gl.RGBA;
+  const width = 1;
+  const height = 1;
+  const border = 0;
+  const srcFormat = gl.RGBA;
+  const srcType = gl.UNSIGNED_BYTE;
+  const pixel = new Uint8Array([0, 0, 0, 255]);
+
+  gl.texImage2D(
+    gl.TEXTURE_2D,
+    level,
+    internalFormat,
+    width,
+    height,
+    border,
+    srcFormat,
+    srcType,
+    pixel
+  );
+
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+
+  return texture;
+};
+
+const loadShader = (
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string
+) => {
+  const shader = gl.createShader(type);
+
+  gl.shaderSource(shader, source);
+
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+
+  return shader;
+};
+
+const initShaderProgram = (gl: WebGLRenderingContext) => {
+  const vertexShader = loadShader(gl, gl.VERTEX_SHADER, vertexShaderSource);
+  const fragmentShader = loadShader(
+    gl,
+    gl.FRAGMENT_SHADER,
+    fragmentShaderSource
+  );
+
+  const shaderProgram = gl.createProgram();
+  gl.attachShader(shaderProgram, vertexShader);
+  gl.attachShader(shaderProgram, fragmentShader);
+  gl.linkProgram(shaderProgram);
+
+  if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
+    return null;
+  }
+
+  return shaderProgram;
+};
+
+export const initBuffers = (
+  gl: WebGLRenderingContext,
+  positions: number[][]
+) => {
+  const positionBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array(positions.flat()),
+    gl.STATIC_DRAW
+  );
+
+  const textureCoordinates = [0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0];
+  const textureCoordBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, textureCoordBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array(textureCoordinates),
+    gl.STATIC_DRAW
+  );
+
+  const indices = [0, 1, 2, 0, 2, 3];
+  const indexBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+  gl.bufferData(
+    gl.ELEMENT_ARRAY_BUFFER,
+    new Uint16Array(indices),
+    gl.STATIC_DRAW
+  );
+
+  return {
+    position: positionBuffer,
+    textureCoord: textureCoordBuffer,
+    indices: indexBuffer,
+  };
+};
+
+const initCanvas = (videoWidth: string, videoHeight: string) => {
+  const canvas = document.getElementById('glcanvas') as HTMLCanvasElement;
+  canvas.setAttribute('width', videoWidth);
+  canvas.setAttribute('height', videoHeight);
+  const gl = (canvas.getContext('webgl', { alpha: false }) ||
+    canvas.getContext('experimental-webgl', {
+      alpha: false,
+    })) as WebGLRenderingContext;
+
+  return gl;
+};
+
+export const initConfig = (positions: number[][]) => {
+  const gl = initCanvas(
+    video.get('videoWidth').toString(),
+    video.get('videoHeight').toString()
+  );
+
+  const buffers = initBuffers(gl, positions);
+
+  const shaderProgram = initShaderProgram(gl);
+
+  const programInfo = {
+    program: shaderProgram,
+    attribLocations: {
+      vertexPosition: gl.getAttribLocation(shaderProgram, 'aVertexPosition'),
+      textureCoord: gl.getAttribLocation(shaderProgram, 'aTextureCoord'),
+    },
+    uniformLocations: {
+      projectionMatrix: gl.getUniformLocation(
+        shaderProgram,
+        'uProjectionMatrix'
+      ),
+      modelViewMatrix: gl.getUniformLocation(shaderProgram, 'uModelViewMatrix'),
+      uSampler: gl.getUniformLocation(shaderProgram, 'uSampler'),
+    },
+  };
+
+  const texture = initTexture(gl);
+
+  return {
+    gl,
+    buffers,
+    shaderProgram,
+    programInfo,
+    texture,
+  };
+};
+
+export const clearCanvas = (gl: WebGLRenderingContext) => {
+  gl.clearColor(0.0, 0.0, 0.0, 1.0);
+  gl.clearDepth(1.0);
+  gl.enable(gl.DEPTH_TEST);
+  gl.enable(gl.BLEND);
+  gl.depthFunc(gl.LEQUAL);
+
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+};

--- a/client/src/webgl/webglController.ts
+++ b/client/src/webgl/webglController.ts
@@ -97,7 +97,7 @@ class WebglController {
   }
 
   rotateLeft90Degree = () => {
-    this.phase += 1;
+    this.phase += this.flip ? -1 : 1;
 
     this.rate *= this.rotate
       ? this.gl.canvas.width / this.gl.canvas.height
@@ -107,7 +107,7 @@ class WebglController {
   };
 
   rotateRight90Degree = () => {
-    this.phase -= 1;
+    this.phase += this.flip ? 1 : -1;
 
     this.rate *= this.rotate
       ? this.gl.canvas.width / this.gl.canvas.height
@@ -254,16 +254,16 @@ class WebglController {
   };
 
   drawSign = (modelViewMatrix, projectionMatrix, programInfo) => {
-    if (this.flip) {
-      mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
-    }
-
     mat4.rotate(
       modelViewMatrix,
       modelViewMatrix,
       ((-1 * this.phase * 90) / 180) * Math.PI,
       [0.0, 0.0, 1.0]
     );
+
+    if (this.flip) {
+      mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
+    }
 
     mat4.scale(modelViewMatrix, modelViewMatrix, [
       1 / (this.rate * this.rate),
@@ -365,16 +365,16 @@ class WebglController {
 
     mat4.scale(modelViewMatrix, modelViewMatrix, [this.ratio, this.ratio, 1.0]);
 
+    if (this.flip) {
+      mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
+    }
+
     mat4.rotate(
       modelViewMatrix,
       modelViewMatrix,
       ((this.phase * 90) / 180) * Math.PI,
       [0.0, 0.0, 1.0]
     );
-
-    if (this.flip) {
-      mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
-    }
 
     if (this.encode) {
       mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
@@ -473,12 +473,20 @@ class WebglController {
     this.signGrid.src = gridImg;
   };
 
+  initProps = () => {
+    this.rotate = false;
+    this.flip = false;
+    this.encode = false;
+    this.sign = null;
+    this.rate = 1;
+    this.phase = 0;
+    this.ratio = 1;
+  };
+
   clear = () => {
     this.positions = this.init.positions.map(pair => [...pair]);
     this.buffers = initBuffers(this.gl, this.positions);
-    this.rotate = false;
-    this.flip = false;
-    this.rate = 1;
+    this.initProps();
   };
 
   reset = () => {

--- a/client/src/webgl/webglController.ts
+++ b/client/src/webgl/webglController.ts
@@ -171,34 +171,6 @@ class WebglController {
     return pixels;
   };
 
-  encodeTexture = res => {
-    return new Promise(resolve => {
-      this.encode = true;
-
-      this.gl.bindTexture(this.gl.TEXTURE_2D, this.texture);
-      this.gl.texImage2D(
-        this.gl.TEXTURE_2D,
-        level,
-        this.internalFormat,
-        this.srcFormat,
-        this.srcType,
-        res
-      );
-
-      this.drawScene(this.programInfo, this.texture);
-
-      createImageBitmap(
-        this.gl.canvas,
-        0,
-        0,
-        this.gl.canvas.width,
-        this.gl.canvas.height
-      ).then(resultImage => {
-        resolve(resultImage);
-      });
-    });
-  };
-
   updateTexture = (texture: WebGLTexture) => {
     this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
     this.gl.texImage2D(
@@ -390,6 +362,23 @@ class WebglController {
       1.0,
       1.0,
     ]);
+
+    mat4.scale(modelViewMatrix, modelViewMatrix, [this.ratio, this.ratio, 1.0]);
+
+    mat4.rotate(
+      modelViewMatrix,
+      modelViewMatrix,
+      ((this.phase * 90) / 180) * Math.PI,
+      [0.0, 0.0, 1.0]
+    );
+
+    if (this.flip) {
+      mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
+    }
+
+    if (this.encode) {
+      mat4.scale(modelViewMatrix, modelViewMatrix, [1.0, -1.0, 1.0]);
+    }
 
     this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffers.position);
     this.gl.vertexAttribPointer(

--- a/client/webpack.common.ts
+++ b/client/webpack.common.ts
@@ -43,6 +43,10 @@ module.exports = {
           limit: 10000,
         },
       },
+      {
+        test: /\.js$/,
+        loader: require.resolve('@open-wc/webpack-import-meta-loader'),
+      },
     ],
   },
   plugins: [

--- a/server/webpack.config.js
+++ b/server/webpack.config.js
@@ -1,7 +1,11 @@
 const path = require('path');
 
+const mode =
+  process.env.NODE_ENV === 'production' ? 'production' : 'development';
+
 module.exports = {
   entry: './bin/www.ts',
+  mode,
   module: {
     rules: [
       {


### PR DESCRIPTION
# 개요
- `mp4-h264`라이브러리를 활용하여 편집된 영상 인코딩 -> mp4추출
- 추출된 mp4 로컬로 다운로드
- 서명 기능 구현 (history에는 미반영)
- history 각종 오류 수정
- CropLayer 가 선택되지 않던 문제 해결
- 원본으로 돌아가는 경우 webgl이 초기화되지 않던 문제 해결
- 이전에 편집하던 영상의 history 가 초기화되지 않던 문제 해결

# 체크리스트
- [x] 영상을 편집한 이후 인코딩이 정상적으로 되는지 확인
- [x] 편집된 영상을 다운로드하시겠습니까? -> 예를 한 경우 영상이 로컬로 다운로드되는지 확인
- [x] 서명 기능이 정상적으로 동작하는지 확인
  - [x] 서명을 추가한 후 영상을 회전하거나 반전해도 서명이 유지되는지 확인
- [x] 새로운 영상을 불러오면 Webgl filter / 서명이 초기화되는지 확인
- [x] CropLayer가 정상적으로 작동하고 자르기도 잘 되는지 확인
- [x] 영상을 편집하다가 새로운 영상을 불러오는 경우 history와 webgl이 초기화되는지 확인
- [x] history가 정상적으로 동작하는지 확인