### PR TITLE
[FE] 각종 오류 수정

### DIFF
--- a/client/src/components/molecules/CurrentTime/CurrentTime.tsx
+++ b/client/src/components/molecules/CurrentTime/CurrentTime.tsx
@@ -22,9 +22,7 @@ const getVideoCurrentTime = () => video.get('currentTime');
 const CurrentTime: React.FC = () => {
   const { start, end } = useSelector(getStartEnd, shallowEqual);
   const isCrop = useSelector(getIsCrop);
-  const [time, setTime] = useState(
-    Math.floor(getVideoCurrentTime() - (!isCrop && start))
-  );
+  const [time, setTime] = useState(0);
   const visible = useSelector(getVisible);
 
   const dispatch = useDispatch();
@@ -46,8 +44,7 @@ const CurrentTime: React.FC = () => {
         if (time !== newTime) setTime(newTime);
       }, 50);
     return () => clearInterval(timer);
-  }, [isCrop, visible, start, end]);
-
+  }, [isCrop, time, visible, start, end]);
   return (
     <StyledDiv>
       <TimeText time={time} color={visible ? undefined : 'transparent'} />

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -187,18 +187,19 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
   const handleInputChange = useCallback(({ target }) => {
     const file = (target as HTMLInputElement).files[0];
     const img = document.createElement('img');
-
     setIsSign(!!file);
     img.src = URL.createObjectURL(file);
-    webglController.setSign(img);
-    webglController.setSignEdit(true);
+    img.addEventListener('load', () => {
+      webglController.setSign(img);
+      webglController.setSignEdit(true);
+    });
   }, []);
-
   const removeSignEvent = () => {
     const canvas = document.getElementById('glcanvas');
     canvas.removeEventListener('mousedown', handleCanvasMouseDown);
     canvas.removeEventListener('mousedown', handleCanvasMouseUp);
     input.removeEventListener('change', handleInputChange);
+    input.value = null;
   };
 
   const closeSubtool = () => {

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -8,7 +8,12 @@ import ButtonGroup from '@/components/molecules/ButtonGroup';
 import UploadArea from '@/components/molecules/UploadArea';
 import video from '@/video';
 import { play, pause, moveTo } from '@/store/currentVideo/actions';
-import { getStartEnd, getPlaying, getVisible } from '@/store/selectors';
+import {
+  getStartEnd,
+  getPlaying,
+  getVisible,
+  getMessage,
+} from '@/store/selectors';
 import { cropStart, cropCancel, cropConfirm } from '@/store/crop/actions';
 import webglController from '@/webgl/webglController';
 import reducer, { initialData, ButtonTypes } from './reducer';
@@ -86,7 +91,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
   const [buttonData, dispatchButtonData] = useReducer(reducer, initialData);
   const hasEmptyVideo = !useSelector(getVisible);
   const [isSign, setIsSign] = useState(false);
-
+  const message = useSelector(getMessage);
   const { start, end } = useSelector(getStartEnd, shallowEqual);
 
   const glCanvas = document.getElementById('glcanvas');
@@ -130,20 +135,22 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
 
   document.onkeydown = (event: KeyboardEvent) => {
     const element = document.activeElement as HTMLButtonElement;
-    if (element.tagName !== 'INPUT') element.blur();
 
-    switch (event.code) {
-      case 'ArrowLeft':
-        backwardVideo();
-        break;
-      case 'Space':
-        playPauseVideo();
-        break;
-      case 'ArrowRight':
-        forwardVideo();
-        break;
-      default:
-        break;
+    if (element.tagName !== 'INPUT' && message === '') {
+      element.blur();
+      switch (event.code) {
+        case 'ArrowLeft':
+          backwardVideo();
+          break;
+        case 'Space':
+          playPauseVideo();
+          break;
+        case 'ArrowRight':
+          forwardVideo();
+          break;
+        default:
+          break;
+      }
     }
   };
 

--- a/client/src/components/organisms/Tools/Tools.tsx
+++ b/client/src/components/organisms/Tools/Tools.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useReducer, useCallback, useMemo } from 'react';
+import React, {
+  useState,
+  useReducer,
+  useCallback,
+  useMemo,
+  useEffect,
+} from 'react';
 import styled, { keyframes } from 'styled-components';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 
@@ -13,6 +19,7 @@ import {
   getPlaying,
   getVisible,
   getMessage,
+  getIsCancel,
 } from '@/store/selectors';
 import { cropStart, cropCancel, cropConfirm } from '@/store/crop/actions';
 import webglController from '@/webgl/webglController';
@@ -93,7 +100,7 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
   const [isSign, setIsSign] = useState(false);
   const message = useSelector(getMessage);
   const { start, end } = useSelector(getStartEnd, shallowEqual);
-
+  const isCancel = useSelector(getIsCancel);
   const glCanvas = document.getElementById('glcanvas');
   const input = document.createElement('input');
 
@@ -196,12 +203,10 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
 
   const closeSubtool = () => {
     removeSignEvent();
-
     setEdit(DOWN);
     setToolType(null);
     dispatchButtonData({ type: null });
   };
-
   const openSubtool = (type: ButtonTypes, payload: (() => void)[]) => {
     removeSignEvent();
     webglController.setSignEdit(false);
@@ -288,6 +293,11 @@ const Tools: React.FC<props> = ({ setEdit, isEdit }) => {
       if (webglController.sign) webglController.setSignEdit(true);
     } else closeSubtool();
   };
+  useEffect(() => {
+    if (toolType !== null) {
+      closeSubtool();
+    }
+  }, [isCancel]);
 
   return (
     <StyledDiv>

--- a/client/src/store/crop/actions.ts
+++ b/client/src/store/crop/actions.ts
@@ -1,4 +1,9 @@
-import { CROP_START, CROP_CANCEL, CROP_CONFIRM } from '../actionTypes';
+import {
+  CROP_START,
+  CROP_CANCEL,
+  CROP_CONFIRM,
+  ResetAction,
+} from '../actionTypes';
 import { CropAction } from '../currentVideo/actions';
 
 export const cropStart = () => ({
@@ -29,4 +34,5 @@ export type CropStoreAction =
   | CropStartAction
   | CropCancelAction
   | CropConfirmAction
-  | CropAction;
+  | CropAction
+  | ResetAction;

--- a/client/src/store/crop/reducer.ts
+++ b/client/src/store/crop/reducer.ts
@@ -1,4 +1,10 @@
-import { CROP_START, CROP_CANCEL, CROP_CONFIRM, CROP } from '../actionTypes';
+import {
+  CROP_START,
+  CROP_CANCEL,
+  CROP_CONFIRM,
+  CROP,
+  RESET,
+} from '../actionTypes';
 import { CropStoreAction } from './actions';
 
 export interface CropState {
@@ -36,6 +42,8 @@ export default (
         isCrop: false,
         isCropConfirm: false,
       };
+    case RESET:
+      return initialState;
     default:
       return state;
   }

--- a/client/src/store/currentVideo/reducer.ts
+++ b/client/src/store/currentVideo/reducer.ts
@@ -17,6 +17,7 @@ export interface CurrentVideoState {
   end: number;
   playing: boolean;
   thumbnails: string[];
+  isCancel: boolean;
 }
 
 const initialState: CurrentVideoState = {
@@ -25,6 +26,7 @@ const initialState: CurrentVideoState = {
   end: 0,
   playing: false,
   thumbnails: [],
+  isCancel: false,
 };
 
 export default (
@@ -57,6 +59,7 @@ export default (
       return {
         ...state,
         ...action.payload,
+        isCancel: false,
       };
     case CROP:
       return {
@@ -65,7 +68,10 @@ export default (
         end: action.payload.current.end,
       };
     case RESET:
-      return initialState;
+      return {
+        ...initialState,
+        isCancel: true,
+      };
     case ERROR:
     default:
       return state;

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -25,6 +25,9 @@ export const getStartEnd = (state: RootState) => {
 };
 export const getThumbnails = (state: RootState) =>
   state.currentVideo.thumbnails;
+export const getIsCancel = (state: RootState) => {
+  return state.currentVideo.isCancel;
+};
 
 // crop
 export const getIsCrop = (state: RootState) => state.crop.isCrop;


### PR DESCRIPTION
# 개요
- 10초미만만큼의 시간이 흐른 후, 뒤로가기를 누르면  currentTime update가 안되는 오류 수정
- 로딩화면이 떠있거나 모달이 떠있는 상태일때 키보드 동작되는 오류 수정
- subTool 나와있는 상태에서 취소버튼누르면 subTool 그대로 노출되는 오류 수정
- 서명 똑같은거 불리면 안되는 오류 수정

# 체크리스트
- [x] 영상을 5초까지 재생한 후, 뒤로가기를 누르면 currentTime이 0초가되는 것을 확인한다
- [x] 로딩화면이 떠있는 상태에서 키보드 동작(앞/뒤로 10초,재생/정지)이 되지않는 것을 확인한다
- [x] 파일의 이름을 입력할 때, 키보드 동작이 input창에서만 되는 것을 확인한다
- [x] subTool이 나와있는 상태에서 취소버튼을 누르면 subTool이 들어가는 것을 확인한다
- [x] crop subTool 이 나와있는 상태에서 취소버튼을 누르면 subTool이 들어가고 range,thumbnail이 보이지않는 것을 확인한다
- [x] 동일한 서명 이미지를 올렸을 때 가능한 것을 확인한다.